### PR TITLE
fix: 401 refreshToken refreshPromise 방식 적용으로 무한 루프 방지 로직 추가

### DIFF
--- a/apps/crew/src/api/interceptor.ts
+++ b/apps/crew/src/api/interceptor.ts
@@ -5,6 +5,10 @@ import { authToken } from '@/store/tokenStore';
 
 import { authApi } from './index';
 
+type RetryableRequestConfig = InternalAxiosRequestConfig & {
+  _retry?: boolean;
+};
+
 export const checkToken = (config: InternalAxiosRequestConfig) => {
   const token = getAuthToken();
 
@@ -12,52 +16,63 @@ export const checkToken = (config: InternalAxiosRequestConfig) => {
     if (authToken.get() !== token) {
       authToken.set(token);
     }
+
     config.headers.Authorization = `Bearer ${token}`;
   }
 
   return config;
 };
 
-let lock = false;
-
-const checkLock = () => lock;
-
-const setLock = (value: boolean) => {
-  lock = value;
-};
+let refreshPromise: Promise<string> | null = null;
 
 export const refreshToken = async (error: AxiosError<unknown>, instance: AxiosInstance) => {
-  const originRequest = error.config;
+  const originRequest = error.config as RetryableRequestConfig | undefined;
 
   if (!error.response || !originRequest) throw new Error('에러가 발생했습니다.');
 
   const { status } = error.response;
 
   if (status === 401) {
-    if (checkLock()) return instance(originRequest);
-    setLock(true);
-
-    const currentToken = getAuthToken();
-    try {
-      const { data } = await authApi.post<{ data: { accessToken: string } }>(`/api/v1/auth/refresh/web`, null, {
-        headers: {
-          Authorization: `Bearer ${currentToken}`,
-        },
-      });
-      originRequest.headers.Authorization = `Bearer ${data.data.accessToken}`;
-      localStorage.setItem(ACCESS_TOKEN_KEY, data.data.accessToken);
-      instance.defaults.headers.common['Authorization'] = `Bearer ${data.data.accessToken}`;
-
-      return instance(originRequest);
-    } catch (error) {
-      console.error(error);
-      localStorage.removeItem(ACCESS_TOKEN_KEY);
-      redirectToLoginPage();
-
-      throw new Error('토큰 갱신에 실패하였습니다.');
-    } finally {
-      setLock(false);
+    if (originRequest._retry) {
+      return Promise.reject(error);
     }
+
+    originRequest._retry = true;
+
+    if (!refreshPromise) {
+      const currentToken = getAuthToken();
+
+      if (!currentToken) {
+        redirectToLoginPage();
+        return Promise.reject(error);
+      }
+
+      refreshPromise = authApi
+        .post<{ data: { accessToken: string } }>(`/api/v1/auth/refresh/web`, null, {
+          headers: {
+            Authorization: `Bearer ${currentToken}`,
+          },
+        })
+        .then(({ data }) => {
+          const newToken = data.data.accessToken;
+          localStorage.setItem(ACCESS_TOKEN_KEY, newToken);
+          authToken.set(newToken);
+          return newToken;
+        })
+        .catch((err) => {
+          console.error(err);
+          localStorage.removeItem(ACCESS_TOKEN_KEY);
+          redirectToLoginPage();
+          throw err;
+        })
+        .finally(() => {
+          refreshPromise = null;
+        });
+    }
+
+    const newToken = await refreshPromise;
+    originRequest.headers.Authorization = `Bearer ${newToken}`;
+    return instance(originRequest);
   }
 
   return Promise.reject(error);


### PR DESCRIPTION
> [!WARNING]
> update 26.4.8)
> 충돌 해결하다가 이상하게 날라가서,,,, pr 다시 열었습니닷,, 
> 이전 [PR](https://github.com/sopt-makers/sopt-makers-frontend/pull/17)에서 comment 확인해주세여!


## 📋 작업 내용
401 응답 처리 인터셉터에서 발생하던 **무한루프 버그**를 수정하고, `lock` 플래그 방식을 `refreshPromise` 공유 방식으로 리팩토링

## 📌 PR Point

### ✅ 문제: lock 방식의 핵심 버그
  
요청 A, B, C가 동시에 401을 받는 상황:
 
```md
A, B, C → 401 수신 → interceptor 진입

A: checkLock() === false → setLock(true) → /refresh 호출 시작
B: checkLock() === true  → return instance(originRequest) ← 문제
C: checkLock() === true  → return instance(originRequest) ← 문제
```
 
`lock === true`일 때 `instance(originRequest)`를 **즉시** 리턴합니다. refresh 완료를 await하지 않기 때문에 **아직 만료된 토큰**으로 재전송이 일어납니다.
 
```ts
// 기존 코드 (문제)
if (checkLock()) return instance(originRequest); // await 없이 즉시 재전송
```
 
결과: B, C는 만료 토큰으로 재전송 → 또 401 → 또 interceptor 진입 → 무한루프
 
<br/>
 
### ✅ 해결: refreshPromise 공유 방식 
401인 API 모두 동일한 promise를 공유합니다. 

```ts
let refreshPromise: Promise<string> | null = null;
```
 
- `null`이면: refresh API 호출 후 그 Promise를 저장
- `null`이 아니면: 이미 진행 중인 Promise를 그대로 `await`
 
```ts
if (!refreshPromise) {
  refreshPromise = authApi.post(...)
    .then(({ data }) => {
      const newToken = data.data.accessToken;
      localStorage.setItem(ACCESS_TOKEN_KEY, newToken);
      return newToken;
    })
    .finally(() => {
      refreshPromise = null; // 완료 후 초기화
    });
}
 
const newToken = await refreshPromise; // A, B, C 모두 여기서 대기
originRequest.headers.Authorization = `Bearer ${newToken}`;
return instance(originRequest); // 새 토큰으로 재전송
```

### 요약
<img width="837" height="469" alt="image" src="https://github.com/user-attachments/assets/bce468cc-008d-426b-a65d-8f203fc58646" />

`made by claude`
