### PR TITLE
fix: 플그 피드 캐러셀 수정

### DIFF
--- a/apps/playground/src/components/common/HorizontalScroller/index.tsx
+++ b/apps/playground/src/components/common/HorizontalScroller/index.tsx
@@ -127,6 +127,7 @@ const ScrollContainer = styled.div`
   display: flex;
   position: relative;
   overflow-x: scroll;
+  overflow-y: hidden;
   white-space: nowrap;
   scrollbar-width: none;
 

--- a/apps/playground/src/components/feed/list/FeedCard.tsx
+++ b/apps/playground/src/components/feed/list/FeedCard.tsx
@@ -347,11 +347,20 @@ const renderContent = (
   return parsed;
 };
 
+const FEED_CARD_SPACE = 16;
+
 const Image = ({ children }: PropsWithChildren<unknown>) => {
   return (
-    <HorizontalScroller>
+    <HorizontalScroller
+      css={{
+        marginLeft: -FEED_CARD_SPACE,
+        marginRight: -FEED_CARD_SPACE,
+      }}
+    >
       <Flex
         css={{
+          paddingLeft: FEED_CARD_SPACE,
+          paddingRight: FEED_CARD_SPACE,
           gap: '8px',
           whiteSpace: 'nowrap',
         }}

--- a/apps/playground/src/components/feed/list/FeedCard.tsx
+++ b/apps/playground/src/components/feed/list/FeedCard.tsx
@@ -347,20 +347,20 @@ const renderContent = (
   return parsed;
 };
 
-const FEED_CARD_SPACE = 16;
+const FEED_CARD_SIDE_SPACE = 16;
 
 const Image = ({ children }: PropsWithChildren<unknown>) => {
   return (
     <HorizontalScroller
       css={{
-        marginLeft: -FEED_CARD_SPACE,
-        marginRight: -FEED_CARD_SPACE,
+        marginLeft: -FEED_CARD_SIDE_SPACE,
+        marginRight: -FEED_CARD_SIDE_SPACE,
       }}
     >
       <Flex
         css={{
-          paddingLeft: FEED_CARD_SPACE,
-          paddingRight: FEED_CARD_SPACE,
+          paddingLeft: FEED_CARD_SIDE_SPACE,
+          paddingRight: FEED_CARD_SIDE_SPACE,
           gap: '8px',
           whiteSpace: 'nowrap',
         }}

--- a/apps/playground/src/components/feed/list/FeedCard.tsx
+++ b/apps/playground/src/components/feed/list/FeedCard.tsx
@@ -347,21 +347,11 @@ const renderContent = (
   return parsed;
 };
 
-const FEED_CARD_LEFT_SPACE = 58;
-const FEED_CARD_RIGHT_SPACE = 16;
-
 const Image = ({ children }: PropsWithChildren<unknown>) => {
   return (
-    <HorizontalScroller
-      css={{
-        marginLeft: -FEED_CARD_LEFT_SPACE,
-        marginRight: -FEED_CARD_RIGHT_SPACE,
-      }}
-    >
+    <HorizontalScroller>
       <Flex
         css={{
-          paddingLeft: FEED_CARD_LEFT_SPACE,
-          paddingRight: FEED_CARD_RIGHT_SPACE,
           gap: '8px',
           whiteSpace: 'nowrap',
         }}
@@ -379,18 +369,9 @@ const Comment = ({ children }: PropsWithChildren<unknown>) => {
     <HorizontalScroller
       css={{
         marginTop: '4px',
-        marginLeft: -FEED_CARD_LEFT_SPACE,
-        marginRight: -FEED_CARD_RIGHT_SPACE,
       }}
     >
-      <StyledComment
-        css={{
-          paddingLeft: FEED_CARD_LEFT_SPACE,
-          paddingRight: FEED_CARD_RIGHT_SPACE,
-        }}
-      >
-        {children}
-      </StyledComment>
+      <StyledComment>{children}</StyledComment>
     </HorizontalScroller>
   );
 };

--- a/apps/playground/src/components/feed/list/FeedCard.tsx
+++ b/apps/playground/src/components/feed/list/FeedCard.tsx
@@ -378,9 +378,18 @@ const Comment = ({ children }: PropsWithChildren<unknown>) => {
     <HorizontalScroller
       css={{
         marginTop: '4px',
+        marginLeft: -FEED_CARD_SIDE_SPACE,
+        marginRight: -FEED_CARD_SIDE_SPACE,
       }}
     >
-      <StyledComment>{children}</StyledComment>
+      <StyledComment
+        css={{
+          paddingLeft: FEED_CARD_SIDE_SPACE,
+          paddingRight: FEED_CARD_SIDE_SPACE,
+        }}
+      >
+        {children}
+      </StyledComment>
     </HorizontalScroller>
   );
 };


### PR DESCRIPTION
## 📋 작업 내용

- [x] 캐러셀 세로 스크롤 잡히는 문제 해결
- [x] 캐러셀이 피드 영역 밖으로 튀어나오는 문제 해결

## 📌 PR Point

```tsx
// before
const FEED_CARD_LEFT_SPACE = 58;
const FEED_CARD_RIGHT_SPACE = 16;
```
- 기존 캐러셀에 `FEED_CARD_LEFT_SPACE`가 피드 카드 padding 값보다 큰 값으로 적용이 되어 있어 캐러셀 스크롤 시 피드 영역 밖으로 튀어나오는 문제가 있었어요.
- 예전 레이아웃에서는 프로필 이미지가 왼쪽에 별도로 있어서 피드 카드의 padding 보다 더 큰 값으로 설정했었는데,
      현재 레이아웃처럼 프로필 이미지가 피드 카드 내용 영역에 합쳐지도록 디자인이 바뀌면서 `FEED_CARD_LEFT_SPACE` 값을 조정하지 않아서 발생한 문제로 보여요.

```tsx
// after
const FEED_CARD_SPACE = 16;
```
- 아예 `FEED_CARD_LEFT_SPACE`, `FEED_CARD_RIGHT_SPACE`를 없앨까 하다가 관련 PR을 읽어보니 실제 디자인 의도가 스크롤 영역이 좌우 padding 영역에 의해 잘리지 않는 것이라고 언급되어 있어서 피드 카드 좌우 padding 값인 16을 `FEED_CARD_SPACE`로 합쳐서 관리하도록 수정했어요.

## 📸 스크린샷

https://github.com/user-attachments/assets/64585447-6c22-41bc-a816-9f769cd51c95

