### PR TITLE
fix: 프로젝트 표지 이미지 덮는 이슈 해결

### DIFF
--- a/apps/playground/src/components/common/Footer/index.tsx
+++ b/apps/playground/src/components/common/Footer/index.tsx
@@ -46,7 +46,7 @@ const StyledFooter = styled.div<{ hide: boolean }>`
   position: fixed;
   bottom: 0;
   transition: transform 0.3s;
-  z-index: ${zIndex.헤더 + 1};
+  z-index: ${zIndex.푸터};
   border-top: 1px solid ${colors.gray600};
   background-color: ${colors.gray800};
   padding: 0 0 0 38px;

--- a/apps/playground/src/components/common/Footer/index.tsx
+++ b/apps/playground/src/components/common/Footer/index.tsx
@@ -46,7 +46,7 @@ const StyledFooter = styled.div<{ hide: boolean }>`
   position: fixed;
   bottom: 0;
   transition: transform 0.3s;
-  z-index: ${zIndex.헤더}+1;
+  z-index: ${zIndex.헤더 + 1};
   border-top: 1px solid ${colors.gray600};
   background-color: ${colors.gray800};
   padding: 0 0 0 38px;

--- a/apps/playground/src/styles/zIndex.ts
+++ b/apps/playground/src/styles/zIndex.ts
@@ -1,3 +1,4 @@
 export const zIndex = {
   헤더: 100,
+  푸터: 101,
 };


### PR DESCRIPTION
## 📋 작업 내용

- [x] footer z-index 표현식 수정

## 📌 PR Point

- #34 

표지 이미지가 1개일 때는 정상인데 이미지가 여러개일 때는 footer가 뒤덮이고 있었어요.
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/9ce42403-643d-4d86-be12-796c4133fa97" />

<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/e950d994-b52f-4bd1-9a59-5a8dda0b6086" />

따라서 `ProjectDetail`를 확인해봤습니다
```tsx
{project?.images.length === 1 && (
        <MainImageWrapper>
          <MainImage src={mainImage} alt={project?.name} />
        </MainImageWrapper>
      )}
      {(project?.images ?? []).length > 1 && <StyledProjectImageSlider images={project?.images ?? []} />}
```
이미지가 여러개일 때에는 `ProjectImageSlider`라는 컴포넌트를 사용하고 있었어요.
이 컴포넌트에서 index 문제가 있을거라 예상하고 코드를 확인하는데 index 관련된 코드가 존재하지 않았어요.

footer 컴포넌트를 확인해보니 z-index 표현식이 잘못되어 있더라고요. 그래서 z-index 적용이 안되고 있던 것 같았습니다.
왜 `ProjectDetail`에서만 이런 문제가 발생하는지에 대해 궁금해져서 알아봤어요(JW)

> footer는 position이 fixed라서 z-index가 auto로 되더라도 z-index가 없는 일반 요소들보다는 위에 렌더링돼서 z-index 표현식이 잘못되어 있어도 대부분의 페이지에서는 문제가 발생하지 않았더라고요.
근데 Swiper는 내부적으로 `.swiper-wrapper`에 `transform: translate3d(0, 0, 0)`을 적용하는데 이 부분때문에 새로운 stacking context를 생성하고 swiper 기본 css가 z-index: 1도 함께 설정해서 footer의 z-index가 제대로 적용되지 않은 상태에서는 Swiper가 footer 위로 올라가게 되면서 요런 문제가 발생했던 것 같습니다

## 📸 스크린샷

> before
> 
> https://github.com/user-attachments/assets/92148f42-9551-479d-8cc4-d4eff7eb992d

> after
> 
> https://github.com/user-attachments/assets/208c5ea1-f5ca-45b2-a098-9367dbf3c118

