### PR TITLE
feat: 에스크 탭 안내 카드 및 N 태그 구현

### DIFF
--- a/apps/playground/src/api/endpoint/members/postMemberQuestion.ts
+++ b/apps/playground/src/api/endpoint/members/postMemberQuestion.ts
@@ -32,11 +32,12 @@ export const usePostMemberAsk = () => {
 
   return useMutation({
     mutationFn: (params: PostMemberAskRequest) => postMemberAsk.request(params),
-    onSuccess: () => {
+    onSuccess: (_, { receiverId }) => {
       queryClient.invalidateQueries({ queryKey: ['getMemberQuestions'] });
       queryClient.invalidateQueries({
         queryKey: ['getUnansweredQuestionCount'],
       });
+      queryClient.invalidateQueries({ queryKey: ['getMemberProfileById', receiverId] });
     },
   });
 };

--- a/apps/playground/src/api/endpoint_LEGACY/members/type.ts
+++ b/apps/playground/src/api/endpoint_LEGACY/members/type.ts
@@ -67,6 +67,7 @@ export type ProfileDetail = {
   projects: MemberProject[];
   careers: Career[];
   allowOfficial: boolean;
+  hasRecentQuestion: boolean;
   isMine: boolean;
   isPhoneBlind: boolean;
   isCoffeeChatActivate: boolean;

--- a/apps/playground/src/components/members/detail/ActivitySection/AskTabContent.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/AskTabContent.tsx
@@ -188,6 +188,7 @@ const AskTabContent = ({ memberId, memberName, meId, unansweredCount }: AskTabCo
 
   return (
     <Container>
+      <Info>익명으로도 편하게 물어볼 수 있어요 👀</Info>
       {!hasAnyQuestions ? (
         <EmptyContainer>
           <EmptyTitle>아직 질문이 없어요.</EmptyTitle>
@@ -491,6 +492,21 @@ const Container = styled.div`
   flex-direction: column;
   gap: 20px;
   max-width: 790px;
+`;
+
+const Info = styled.div`
+  margin-bottom: 10px;
+  padding: 16px 20px;
+  border-radius: 12px;
+  background-color: ${colors.gray900};
+  color: ${colors.gray200};
+  ${fonts.TITLE_16_SB};
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    margin-bottom: 4px;
+    padding: 12px 20px;
+    ${fonts.BODY_14_M};
+  }
 `;
 
 const EmptyContainer = styled.div`

--- a/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -3,7 +3,6 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { Tag } from '@sopt-makers/ui';
 import { useRouter } from 'next/router';
-import type { FC } from 'react';
 import { useMemo } from 'react';
 
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
@@ -34,7 +33,7 @@ const TABS: Tab[] = [
   { id: 'ask', label: '에스크' },
 ];
 
-const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
+const MemberDetail = ({ memberId }: MemberDetailProps) => {
   const router = useRouter();
   const { logPageViewEvent, logClickEvent } = useEventLogger();
 
@@ -44,7 +43,7 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
 
   const { data: me } = useGetMemberOfMe();
 
-  const isMyProfile = me?.id !== undefined && String(me.id) === memberId;
+  const isMyProfile = me?.id === safeParseInt(memberId);
 
   const { data: unansweredCountData } = useGetUnansweredQuestionCount({
     enabled: isMyProfile,
@@ -99,15 +98,16 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
       </Container>
     );
 
-  const getAskTabTag = () => {
-    if (isMyProfile && (unansweredCountData?.count ?? 0) > 0) {
-      return unansweredCountData?.count;
+  const unansweredCount = unansweredCountData?.count ?? 0;
+  let askNotificationBadge: number | 'N' | null = null;
+
+  if (isMyProfile) {
+    if (unansweredCount > 0) {
+      askNotificationBadge = unansweredCount;
     }
-    if (!isMyProfile && profile.hasRecentQuestion) {
-      return 'N';
-    }
-    return null;
-  };
+  } else if (profile.hasRecentQuestion) {
+    askNotificationBadge = 'N';
+  }
 
   return (
     <Container>
@@ -115,21 +115,18 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
         <ProfileSection profile={profile} memberId={memberId} />
 
         <TabNavigation>
-          {TABS.map((tab) => {
-            const askTabTag = tab.id === 'ask' ? getAskTabTag() : null;
-            return (
-              <TabButton key={tab.id} isActive={currentTab === tab.id} onClick={() => handleTabChange(tab.id)}>
-                {tab.label}
-                {askTabTag !== null && (
-                  <TagWrapper>
-                    <StyledTag size='sm' variant='primary' shape='pill'>
-                      {askTabTag}
-                    </StyledTag>
-                  </TagWrapper>
-                )}
-              </TabButton>
-            );
-          })}
+          {TABS.map((tab) => (
+            <TabButton key={tab.id} isActive={currentTab === tab.id} onClick={() => handleTabChange(tab.id)}>
+              {tab.label}
+              {tab.id === 'ask' && askNotificationBadge !== null && (
+                <BadgeWrapper>
+                  <Badge size='sm' variant='primary' shape='pill'>
+                    {askNotificationBadge}
+                  </Badge>
+                </BadgeWrapper>
+              )}
+            </TabButton>
+          ))}
         </TabNavigation>
 
         {(() => {
@@ -242,11 +239,11 @@ const TabButton = styled.button<{ isActive: boolean }>`
   }
 `;
 
-const TagWrapper = styled.div`
+const BadgeWrapper = styled.div`
   display: flex;
   align-items: center;
 `;
 
-const StyledTag = styled(Tag)`
+const Badge = styled(Tag)`
   padding: 3px 8px;
 `;

--- a/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -99,24 +99,37 @@ const MemberDetail: FC<MemberDetailProps> = ({ memberId }) => {
       </Container>
     );
 
+  const getAskTabTag = () => {
+    if (isMyProfile && (unansweredCountData?.count ?? 0) > 0) {
+      return unansweredCountData?.count;
+    }
+    if (!isMyProfile && profile.hasRecentQuestion) {
+      return 'N';
+    }
+    return null;
+  };
+
   return (
     <Container>
       <Wrapper>
         <ProfileSection profile={profile} memberId={memberId} />
 
         <TabNavigation>
-          {TABS.map((tab) => (
-            <TabButton key={tab.id} isActive={currentTab === tab.id} onClick={() => handleTabChange(tab.id)}>
-              {tab.label}
-              {tab.id === 'ask' && isMyProfile && (unansweredCountData?.count ?? 0) > 0 && (
-                <TagWrapper>
-                  <StyledTag size='sm' variant='primary' shape='pill'>
-                    {unansweredCountData?.count}
-                  </StyledTag>
-                </TagWrapper>
-              )}
-            </TabButton>
-          ))}
+          {TABS.map((tab) => {
+            const askTabTag = tab.id === 'ask' ? getAskTabTag() : null;
+            return (
+              <TabButton key={tab.id} isActive={currentTab === tab.id} onClick={() => handleTabChange(tab.id)}>
+                {tab.label}
+                {askTabTag !== null && (
+                  <TagWrapper>
+                    <StyledTag size='sm' variant='primary' shape='pill'>
+                      {askTabTag}
+                    </StyledTag>
+                  </TagWrapper>
+                )}
+              </TabButton>
+            );
+          })}
         </TabNavigation>
 
         {(() => {
@@ -174,7 +187,7 @@ const Wrapper = styled.div`
   gap: 30px;
   width: 790px;
   @media ${MOBILE_MEDIA_QUERY} {
-    gap: 24px;
+    gap: 17px;
     width: 100%;
   }
 `;

--- a/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -187,7 +187,7 @@ const Wrapper = styled.div`
   gap: 30px;
   width: 790px;
   @media ${MOBILE_MEDIA_QUERY} {
-    gap: 17px;
+    gap: 16px;
     width: 100%;
   }
 `;


### PR DESCRIPTION
## 📋 작업 내용

- [x] 에스크 탭 상단 info 카드 구현
- [x] N 태그 구현

## 📌 PR Point

**N 태그 로직 관련**
- 내 프로필일 경우 노출 X
- 다른 멤버 프로필이고 최근 7일 이내 등록된 질문이 존재할 경우 노출
    - api 응답값(`hasRecentQuestion` 필드)으로 받아오고 있어요.

## 📸 스크린샷
- 에스크탭 상단 info 카드
<img width="728" height="257" alt="image" src="https://github.com/user-attachments/assets/54e67833-85af-4cc3-b488-5c1ba76b054e" />

- N 태그

https://github.com/user-attachments/assets/80755bbd-126f-4f28-9659-1e4888a564f2

