### PR TITLE
fix: eslint-config에서 import/no-unused-modules 규칙 제거

### DIFF
--- a/packages/eslint-config/next.js
+++ b/packages/eslint-config/next.js
@@ -5,6 +5,5 @@ module.exports = {
   rules: {
     'react/display-name': 'off',
     '@next/next/no-img-element': 'off',
-    'import/no-unused-modules': ['warn', { unusedExports: true }],
   },
 };


### PR DESCRIPTION
## 📋 작업 내용
- #44 

- [x] `'import/no-unused-modules': ['warn', { unusedExports: true }],` 규칙 제거

## 📌 PR Point

기존에 개발할 때 경고등이 엄청 많이 발생했었어요. `(오른쪽에 노란 단무지)`
<img width="1282" height="508" alt="image" src="https://github.com/user-attachments/assets/4cb4cabd-cad0-4fb0-ae34-af6e250f2d5d" />
<img width="764" height="54" alt="image" src="https://github.com/user-attachments/assets/dc54837e-db6c-412f-bc2f-1011a167697b" />

모든 경고에는
`exported declaration 'default' not used within other modules` 라는 경고 문구가 작성 되어있었습니다.
그래서 ESLint가 작동하는 규칙을 찾아보니 `packages/eslint-config/next.js` 파일 안에 `import/no-unused-modules` 이 속성이 켜져있었습니다. 

import/no-unused-modules는 `unusedExports: true` 옵션과 함께 사용할 때 다른 모듈에서 import되지 않는 export를 경고해요.
하지만 crew와 playground는 `Next.js` 앱이고 `Next.js`는 `pages/src/pages` 아래의 파일을 import로 연결하지 않고 파일 시스템 라우팅으로 직접 페이지 엔트리로 사용해요.

그래서 각 페이지의 default export는 실제로는 정상적으로 사용 중이어도 ESLint 입장에서는 `다른 모듈에서 사용되지 않는 export`로 보였고  거의 모든 페이지 파일에서 동일한 경고가 반복적으로 발생했습니다.

그러면 `unusedExports: true` 옵션만 끄면 되지 않을까 싶은데 `import/no-unused-modules`를 `warn`만 남겨둔다고 실질적으로 얻는 검사 효과는 거의 없다고 하네요!

그래도 파일 내부의 unused import나 variable은 기존 `base.js`에 있는 `@typescript-eslint/no-unused-vars`가 계속 확인해줘요.