### PR TITLE
fix: 에스크 카드 QA 반영

### DIFF
--- a/apps/playground/src/components/common/Carousel/index.tsx
+++ b/apps/playground/src/components/common/Carousel/index.tsx
@@ -8,6 +8,7 @@ import CarouselBody from '@/components/common/Carousel/Body';
 import type { CarouselDirection } from '@/components/common/Carousel/useCarousel';
 import useCarousel from '@/components/common/Carousel/useCarousel';
 import LeftArrowIcon from '@/public/icons/icon-arrow-left.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface CarouselProps {
   itemList: ReactNode[];
@@ -137,10 +138,14 @@ const Container = styled.div`
   grid:
     [row1-start] 'left-control list right-control' max-content [row1-end]
     [row2-start] 'indicators indicators indicators' max-content [row2-end] / 0 auto 0;
-  row-gap: 24px;
+  row-gap: 20px;
   width: 100%;
   overflow: visible;
   user-select: none;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    row-gap: 16px;
+  }
 `;
 
 const StyledMotionDiv = styled(m.div)`

--- a/apps/playground/src/components/common/Carousel/index.tsx
+++ b/apps/playground/src/components/common/Carousel/index.tsx
@@ -83,24 +83,26 @@ export default function Carousel({
           <LeftArrowIcon />
         </LeftControl>
       )}
-      <AnimatePresence initial={false} custom={direction}>
-        <StyledMotionDiv
-          key={page}
-          custom={direction}
-          variants={variants}
-          initial='enter'
-          animate='center'
-          transition={{
-            x: { type: 'spring', stiffness: 300, damping: 30 },
-            opacity: { duration: 0.2 },
-          }}
-          onTouchStart={onTouchStart}
-          onTouchMove={onTouchMove}
-          onTouchEnd={onTouchEnd}
-        >
-          <CarouselBody currentItemList={currentItemList} renderContainer={renderItemContainer} />
-        </StyledMotionDiv>
-      </AnimatePresence>
+      <StyledListClip>
+        <AnimatePresence initial={false} custom={direction}>
+          <StyledMotionDiv
+            key={page}
+            custom={direction}
+            variants={variants}
+            initial='enter'
+            animate='center'
+            transition={{
+              x: { type: 'spring', stiffness: 300, damping: 30 },
+              opacity: { duration: 0.2 },
+            }}
+            onTouchStart={onTouchStart}
+            onTouchMove={onTouchMove}
+            onTouchEnd={onTouchEnd}
+          >
+            <CarouselBody currentItemList={currentItemList} renderContainer={renderItemContainer} />
+          </StyledMotionDiv>
+        </AnimatePresence>
+      </StyledListClip>
 
       {isArrow && (
         <RightControl onClick={handleClickRightControl}>
@@ -148,8 +150,15 @@ const Container = styled.div`
   }
 `;
 
-const StyledMotionDiv = styled(m.div)`
+const StyledListClip = styled.div`
   grid-area: list;
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+`;
+
+const StyledMotionDiv = styled(m.div)`
   width: 100%;
 `;
 

--- a/apps/playground/src/components/members/main/MemberList/filters/constants.ts
+++ b/apps/playground/src/components/members/main/MemberList/filters/constants.ts
@@ -71,9 +71,9 @@ export const GENERATION_OPTIONS = (() =>
 
 export const TEAM_OPTIONS: Option[] = [
   { value: '임원진', label: '임원진' },
-  { value: '운영팀', label: '운영팀' },
   { value: '미디어팀', label: '미디어팀' },
   { value: '메이커스', label: '메이커스' },
+  { value: '운영팀', label: '운영팀' },
 ];
 
 export const MBTI = [

--- a/apps/playground/src/components/members/main/MemberList/index.tsx
+++ b/apps/playground/src/components/members/main/MemberList/index.tsx
@@ -716,7 +716,7 @@ const StyledMemberSearch = styled(SearchField)`
 const StyledAskCardList = styled.div`
   margin-bottom: 64px;
   @media ${MOBILE_MEDIA_QUERY} {
-    padding: 12px 0 20px 0;
+    padding: 12px 0 16px 0;
     margin-bottom: 0;
   }
 `;

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -21,7 +21,7 @@ const MemberRecommendSection = () => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(true);
   const [isWideViewport, setIsWideViewport] = useState(false);
 
-  // viewpoint 판단은 추후 상위 컴포넌트로 이동
+  // TODO: viewpoint 판단은 추후 상위 컴포넌트로 이동
   useEffect(() => {
     const media = window.matchMedia(PC_MEDIA_QUERY);
     setIsWideViewport(media.matches);
@@ -41,7 +41,7 @@ const MemberRecommendSection = () => {
       <StyledSectionHeader>
         <StyledSectionTitle>나와 접점이 있는 멤버</StyledSectionTitle>
         {isWideViewport ? (
-          //추후 디자인 시스템 툴팁으로 변경
+          //TODO: 추후 디자인 시스템 툴팁으로 변경
           <Tooltip.Provider>
             <Tooltip.Root open={isTooltipOpen}>
               <Tooltip.Trigger asChild>

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 import { useGetMemberRecommendOfMe } from '@/api/endpoint/members/getMemberRecommendOfMe';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
@@ -11,14 +13,55 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import MemberRecommendCard from '../../common/MemberRecommendCard/MemberRecommendCard';
 import { DESKTOP_TWO_MEDIA_QUERY } from '../contants';
 
+const PC_MEDIA_WIDTH = 1920;
+const PC_MEDIA_QUERY = `screen and (min-width: ${PC_MEDIA_WIDTH}px)`;
+
 const MemberRecommendSection = () => {
   const { data: memberRecommendData, refetch } = useGetMemberRecommendOfMe();
+  const [isTooltipOpen, setIsTooltipOpen] = useState(true);
+  const [isWideViewport, setIsWideViewport] = useState(false);
+
+  // viewpoint 판단은 추후 상위 컴포넌트로 이동
+  useEffect(() => {
+    const media = window.matchMedia(PC_MEDIA_QUERY);
+    setIsWideViewport(media.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => setIsWideViewport(e.matches);
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, []);
+
+  const handleRefreshClick = () => {
+    setIsTooltipOpen(false);
+    refetch();
+  };
 
   return (
     <StyledSection>
       <StyledSectionHeader>
         <StyledSectionTitle>나와 접점이 있는 멤버</StyledSectionTitle>
-        <StyledRefreshIcon onClick={refetch} />
+        {isWideViewport ? (
+          //추후 디자인 시스템 툴팁으로 변경
+          <Tooltip.Provider>
+            <Tooltip.Root open={isTooltipOpen}>
+              <Tooltip.Trigger asChild>
+                <button onClick={handleRefreshClick}>
+                  <StyledRefreshIcon />
+                </button>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <TooltipContent side='top' avoidCollisions={false}>
+                  더 많은 멤버를 찾아보세요!
+                  <TooltipArrow />
+                </TooltipContent>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        ) : (
+          <button onClick={handleRefreshClick}>
+            <StyledRefreshIcon />
+          </button>
+        )}
       </StyledSectionHeader>
       <StyledCardGrid>
         {memberRecommendData?.members.map((member) => (
@@ -82,6 +125,30 @@ const StyledRefreshIcon = styled(RefreshIcon)`
     width: 24px;
     height: 24px;
   }
+`;
+
+const TooltipContent = styled(Tooltip.Content)`
+  position: relative;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background-color: ${colors.gray600};
+  margin: 8px;
+  ${fonts.BODY_13_M}
+  box-shadow:
+    0 1px 4px 0 rgba(12, 12, 13, 0.05),
+    0 1px 4px 0 rgba(12, 12, 13, 0.1);
+`;
+
+const TooltipArrow = styled.div`
+  position: absolute;
+  bottom: -9px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 12px solid ${colors.gray600};
 `;
 
 const StyledCardGrid = styled.div`

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -13,7 +13,7 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import MemberRecommendCard from '../../common/MemberRecommendCard/MemberRecommendCard';
 import { DESKTOP_TWO_MEDIA_QUERY } from '../contants';
 
-const PC_MEDIA_WIDTH = 1920;
+const PC_MEDIA_WIDTH = 1200;
 const PC_MEDIA_QUERY = `screen and (min-width: ${PC_MEDIA_WIDTH}px)`;
 
 const MemberRecommendSection = () => {


### PR DESCRIPTION
## 📋 작업 내용
- #55 
 
- [x] 멤버 검색 활동 필터링 운영팀 순서를 맨 밑으로 변경
- [x] ask 카드 컴포넌트의 padding 스타일 수정
- [x] 캐러셀 컴포넌트 좌우 스크롤 시 레이아웃 깨짐 현상 해결
- [x] 툴팁 말풍선 추가 (1920px이상일 때에만 나오도록 / 새로고침 클릭 시 띄우지 X)
 

## 📌 PR Point

- 툴팁 컴포넌트는 디자인 시스템에 존재하지만 현재는 디자인 시스템이 제대로 반영되지 않은 상태라 우선 radix를 사용해 구현했습니다 ! 추후 디자인 시스템이 적용되면 해당 컴포넌트로 교체할게요 !
- viewport 관련 로직은 상위에서 내려주는 방식이 맞다고 주용님께서 말씀해주셨는데 다만 내부에서 해당 로직을 직접 판단하고 있는 컴포넌트가 많아서 추후 한 번에 정리하는 방향으로 진행하려고 하는데 괜찮을까요?!


## 📸 스크린샷

> before
> 
> <img width="200" alt="image" src="https://github.com/user-attachments/assets/751fd7ff-cb7b-431c-b202-e667c35529af" />
> after
> 
> <img width="200" alt="image" src="https://github.com/user-attachments/assets/6e5670da-908b-4fb3-a2cc-c122723cef54" />

> before
> 
> https://github.com/user-attachments/assets/0ffc0a38-da8f-44d4-ab21-ba1e28006907
>
> after
> 
> https://github.com/user-attachments/assets/11efbf4d-1fbb-4230-bfb9-0e33d91d583d

> before
> 
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/07042552-4567-42a3-b4b1-4e142ffe2445" />
> after
> 
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/d4f3be5c-0329-410c-995a-a320c05f8b48" />
