### PR TITLE
style: 멤버 추천 영역 QA 반영

### DIFF
--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -92,7 +92,8 @@ const StyledChipOverlay = styled.div`
 `;
 
 const StyledInfoWrapper = styled.div`
-  flex-shrink: 0;
+  flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -104,6 +105,9 @@ const StyledInfoWrapper = styled.div`
 `;
 
 const StyledName = styled.p`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: ${colors.gray10};
   ${fonts.HEADING_20_B}
 
@@ -113,6 +117,9 @@ const StyledName = styled.p`
 `;
 
 const StyledMeta = styled.p`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: ${colors.gray200};
   ${fonts.LABEL_14_SB}
 

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -17,7 +17,6 @@ interface MemberRecommendSectionProps {
 
 const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps) => {
   const { data, refetch } = useGetMemberRecommendById(memberId);
-  // TODO: random 로직으로 변경
   const memberRecommendData = data?.members.slice(0, 3);
 
   return (

--- a/apps/playground/src/components/members/main/MemberList/index.tsx
+++ b/apps/playground/src/components/members/main/MemberList/index.tsx
@@ -641,6 +641,7 @@ const StyledMain = styled.main`
   @media ${MOBILE_MEDIA_QUERY} {
     padding: 0 20px;
     width: 100%;
+    max-width: none;
   }
 `;
 

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -86,11 +86,17 @@ const StyledRefreshIcon = styled(RefreshIcon)`
 
 const StyledCardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 12px;
+
+  // TODO: random 로직으로 변경
+  & > *:nth-child(n + 5) {
+    display: none;
+  }
 
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
     grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
 
     // TODO: random 로직으로 변경
     & > *:nth-child(n + 4) {

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -12,7 +12,8 @@ import MemberRecommendCard from '../../common/MemberRecommendCard/MemberRecommen
 import { DESKTOP_TWO_MEDIA_QUERY } from '../contants';
 
 const MemberRecommendSection = () => {
-  const { data: memberRecommendData, refetch } = useGetMemberRecommendOfMe();
+  const { data, refetch } = useGetMemberRecommendOfMe();
+  const memberRecommendData = data?.members;
 
   return (
     <StyledSection>
@@ -21,7 +22,7 @@ const MemberRecommendSection = () => {
         <StyledRefreshIcon onClick={refetch} />
       </StyledSectionHeader>
       <StyledCardGrid>
-        {memberRecommendData?.members.map((member) => (
+        {memberRecommendData?.map((member) => (
           <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
             <MemberRecommendCard
               key={member.id}
@@ -89,7 +90,6 @@ const StyledCardGrid = styled.div`
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
 
-  // TODO: random 로직으로 변경
   & > *:nth-child(n + 5) {
     display: none;
   }
@@ -98,7 +98,6 @@ const StyledCardGrid = styled.div`
     grid-template-columns: repeat(3, 1fr);
     gap: 8px;
 
-    // TODO: random 로직으로 변경
     & > *:nth-child(n + 4) {
       display: none;
     }


### PR DESCRIPTION
## 📋 작업 내용

- [x] 모바일 뷰에서 멤버 추천 카드 간 gap 수정
- [x] grid column 수 변경
- [x] TODO 주석 제거
- [x] 멤버 추천 카드 이름, 기수 및 파트 정보 말줄임표 처리

## 📌 PR Point

- 멤버 추천 카드 UI가 깨져서 `~w1200`은 카드 3개, `w1200~`는 카드 4개를 띄우도록 수정했어요.
- 멤버 추천 데이터 랜덤 로직을 서버에서 관리하기로 결정이 나서 관련 TODO 주석을 제거했어요.
- w769~w1200 일 때 멤버 카드 레이아웃이 깨지는 현상이 있어서 말줄임표 처리를 추가했어요.
- w768 이하일 때 멤버 리스트 레이아웃이 깨지는 현상이 있어서 수정했어요.


## 📸 스크린샷

[before]
<img width="1263" height="171" alt="image" src="https://github.com/user-attachments/assets/8a2d0a53-98da-4fd3-82af-932a17a4c8e4" />

[after]
<img width="1265" height="169" alt="image" src="https://github.com/user-attachments/assets/036c28d0-2965-4952-8359-6647b1c896fc" />

<hr />

[before]
<img width="642" height="184" alt="image" src="https://github.com/user-attachments/assets/562ed739-e139-4c46-b14c-5524a68f14d9" />

[after]
<img width="642" height="177" alt="image" src="https://github.com/user-attachments/assets/93c95b01-d135-47a2-b563-9408ece050db" />

<hr />

[before]
<img width="691" height="178" alt="image" src="https://github.com/user-attachments/assets/6eddf4af-f49e-4762-8850-bdd461455285" />

[after]
<img width="711" height="187" alt="image" src="https://github.com/user-attachments/assets/c22e95b8-b8b8-41c7-9596-cc438c842b6d" />


