### PR TITLE
feat: SP1 멤버 에스크 관련 앰플리튜드 로깅 추가

### DIFF
--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -249,7 +249,6 @@ export interface ClickEvents {
   askContentCard: {
     id: number;
     name: string;
-    referral: string;
   };
   memberAskPreview: {
     id: number;

--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -46,22 +46,26 @@ type Vote = {
 };
 
 export interface ClickEvents {
-  memberCard: MemberCard;
-  projectCard: { id: number };
+  // ==== 인증 ====
   registerLink: undefined;
   registerWith: {
     method: 'facebook' | 'google' | 'apple';
   };
+
+  // ==== 온보딩 배너 ====
   onboardingBannerProjectUpload: undefined;
   onboardingBannerProfileUpload: undefined;
-  projectUpload: {
-    referral: string;
-  };
+
+  // ==== 네비게이션 ====
+  // 헤더
   myProfile: undefined;
   reviewUpload: undefined;
-  editProfile: undefined;
-  submitProfile: undefined;
+  // 푸터
   aboutMakers: undefined;
+
+  // ==== 멤버 ====
+  memberCard: MemberCard;
+  // 멤버 리스트 - 필터
   filterGeneration: {
     generation: string;
   };
@@ -80,7 +84,22 @@ export interface ClickEvents {
   filterOrderBy: {
     orderBy: string;
   };
-  mentoringCarouselButton: undefined;
+  // 멤버 상세
+  TabProfile: {
+    id: number;
+    name: string;
+  };
+  // 프로필 편집
+  editProfile: undefined;
+
+  // ==== 프로젝트 ====
+  projectCard: { id: number };
+  projectUpload: {
+    referral: string;
+  };
+  clickProjectShare: undefined;
+
+  // ==== 멘토링 ====
   mentoringCard: {
     mentorId: number;
   };
@@ -90,15 +109,19 @@ export interface ClickEvents {
   mentorProfileCareer: {
     mentorId: number;
   };
+  mentoringCarouselButton: undefined;
   mentoringApplicationButton: {
     mentorId: number;
   };
   mentorApplicationButton: undefined;
-  wordchainEntry: undefined;
+
+  // ==== 커뮤니티(피드) ====
+  // 글 작성
+  feedUploadButton: undefined;
   communityRulesClick: undefined;
   communityUploadCodeButton: undefined;
   quitUploadCommunity: undefined;
-  // 커뮤니티(피드)
+  // 리스트 / 카드
   feedListCategoryFilter: {
     category: string;
   };
@@ -118,7 +141,6 @@ export interface ClickEvents {
   feedCategoryChipLink: {
     feedId: string;
   };
-  feedUploadButton: undefined;
   feedLike: {
     feedId: string;
     category: string;
@@ -127,26 +149,11 @@ export interface ClickEvents {
     feedId: string;
     category: string;
   };
+  // 투표
+  vote: Vote;
+  voteResult: Vote;
 
-  //환영배너 타임캡솝 cta 버튼 클릭
-  bannerTimeCapsule: {
-    isAlreadySubmitted: boolean;
-  };
-  profileUploadTimeCapsule: undefined;
-
-  // 다짐메시지 노출
-  saveResolutionImage: undefined;
-  bannerOpenResolution: undefined;
-  bannerOpenMyReport: undefined;
-  luckyTimeCapsule: undefined;
-
-  // 프로젝트 등록 후 공유하러 가기
-  clickProjectShare: undefined;
-  coffeechatFilter: {
-    topic_tag: string | undefined;
-    career: string | undefined;
-    part: string | undefined;
-  };
+  // ==== 커피솝 ====
   coffeechatCard: {
     career: string | undefined;
     organization: string | undefined | null;
@@ -158,40 +165,34 @@ export interface ClickEvents {
     part: string[] | undefined;
     channel: string;
   };
-
+  coffeechatFilter: {
+    topic_tag: string | undefined;
+    career: string | undefined;
+    part: string | undefined;
+  };
+  coffeechatSection: {
+    section: string;
+  };
   coffeechatGuide: undefined;
   coffeechatBadge: undefined;
   coffeechatToggleOff: undefined;
   coffeechatToggleOn: undefined;
-  skillAdd: undefined;
+  coffeechatBanner: undefined;
+  coffeechatReviewCard: undefined;
+  gotoCoffeechat: GotoCoffeechat;
+  openCoffeechat: undefined;
+  sendCoffeechat: undefined;
+  senderPhone: undefined;
   messageBadge:
     | {
         isRecommended?: boolean;
       }
     | undefined;
-  gotoCoffeechat: GotoCoffeechat;
 
-  // 광고
-  ads: {
-    id: number | undefined;
-    bannerId: number;
-    pageUrl: string;
-    timeStamp: string;
-  };
-  coffeechatSection: {
-    section: string;
-  };
-  openCoffeechat: undefined;
-  senderPhone: undefined;
-  coffeechatBanner: undefined;
-  sendCoffeechat: undefined;
+  // ==== 끝말잇기 ====
+  wordchainEntry: undefined;
 
-  coffeechatReviewCard: undefined;
-
-  hideAdPopupToday: undefined;
-  adPopupBody: undefined;
-  adPopupClose: undefined;
-
+  // ==== 마이 솝트 리포트 ====
   clickMyReportNavbar: {
     myReportSection: string;
   };
@@ -199,27 +200,38 @@ export interface ClickEvents {
   clickMyReportGotoWordchain: undefined;
   clickMyReportGotoMoimFeed: undefined;
   clickMyReportGotoCoffeesopt: undefined;
+  bannerOpenMyReport: undefined;
 
+  // ==== 활동후기 ====
+  reviewGoToHomepage: undefined;
+
+  // ==== 타임캡솝 ====
+  bannerTimeCapsule: {
+    isAlreadySubmitted: boolean;
+  };
+  profileUploadTimeCapsule: undefined;
   // 다른 기능 이동 모달
   timeCapsuleGotoCrew: undefined;
   timeCapsuleGotoProject: undefined;
   timeCapsuleGotoMember: undefined;
   timeCapsuleGotoCoffeechat: undefined;
+  // 종무식
+  bannerOpenResolution: undefined;
+  luckyTimeCapsule: undefined;
+  saveResolutionImage: undefined;
 
-  reviewGoToHomepage: undefined; // 업로드한 활동후기 보러가기
+  // ==== 홈(광고) ====
+  ads: {
+    id: number | undefined;
+    bannerId: number;
+    pageUrl: string;
+    timeStamp: string;
+  };
+  hideAdPopupToday: undefined;
+  adPopupBody: undefined;
+  adPopupClose: undefined;
 
-  // 투표
-  vote: Vote;
-  voteResult: Vote;
-
-  // 기획경선 특집
-  balancegame: undefined;
-  newmember: undefined;
-
-  TL_list: undefined;
-  TL_introduce: undefined;
-  TL_appjam: undefined;
-  refreshmember: undefined;
+  // ==== 에스크 ====
   CTAAsk: {
     id: number;
     name: string;
@@ -229,16 +241,11 @@ export interface ClickEvents {
     name: string;
     hasRecentAsk: boolean;
   };
-  TabProfile: {
-    id: number;
-    name: string;
-  };
   AskUploadButton: undefined;
   AnswerUploadButton: undefined;
   AskLike: {
     feedId: number;
   };
-
   askContentCard: {
     id: number;
     name: string;
@@ -248,21 +255,34 @@ export interface ClickEvents {
     id: number;
     name: string;
   };
+
+  // ==== 기획경선 특집 ====
+  balancegame: undefined;
+  newmember: undefined;
+  TL_list: undefined;
+  TL_introduce: undefined;
+  TL_appjam: undefined;
+  refreshmember: undefined;
 }
 
 export interface SubmitEvents {
-  searchMember: {
-    content: string;
-  };
-  editProfile: undefined;
+  // ==== 인증 ====
   verify: {
     by: 'phone' | 'email';
+  };
+
+  // ==== 멤버 ====
+  searchMember: {
+    content: string;
   };
   sendMessage: {
     category: string;
     receiverId: number;
     referral: 'mentoringDetail' | 'memberDetail' | 'memberList';
   };
+  editProfile: undefined;
+
+  // ==== 프로젝트 ====
   projectUpload: {
     writerId: string;
   };
@@ -270,10 +290,8 @@ export interface SubmitEvents {
     projectId: string;
     editorId: string;
   };
-  postWordchain: {
-    word: string;
-  };
-  wordchainNewGame: undefined;
+
+  // ==== 커뮤니티(피드) ====
   submitCommunity: {
     category: string | undefined;
     isBlindWriter: boolean;
@@ -281,7 +299,6 @@ export interface SubmitEvents {
     mention: boolean;
   };
   editCommunity: undefined;
-  // 커뮤니티(피드)
   postComment: {
     feedId: string;
     referral: 'more' | 'detail';
@@ -289,8 +306,8 @@ export interface SubmitEvents {
     category: string;
     mention: boolean;
   };
-  //타임캡솝 보관하기
-  makeTimeCapsule: undefined;
+
+  // ==== 커피솝 ====
   searchCoffeeChat: {
     search_content: string;
   };
@@ -304,55 +321,71 @@ export interface SubmitEvents {
   editCoffeechat: undefined;
   coffeechatReview: undefined;
 
-  reviewUpload: undefined; // 활동후기 업로드하기
+  // ==== 끝말잇기 ====
+  postWordchain: {
+    word: string;
+  };
+  wordchainNewGame: undefined;
 
-  // 행운 뽑기
+  // ==== 활동후기 ====
+  reviewUpload: undefined;
+
+  // ==== 타임캡솝 ====
+  makeTimeCapsule: undefined;
   luckyTimeCapsule: {
     event_winner: boolean;
   };
 
-  // 기획경선 특집
-  balancegame: undefined;
+  // ==== 에스크 ====
   submitAsk: {
     feedId: number;
   };
   submitAnswer: {
     feedId: number;
   };
+
+  // ==== 기획경선 특집 ====
+  balancegame: undefined;
 }
 
 export interface PageViewEvents {
+  // ==== 멤버 ====
   memberPageList: undefined;
   memberCard: MemberCard;
+
+  // ==== 멘토링 ====
   mentoringDetail: {
     mentorId: number;
   };
+
+  // ==== 끝말잇기 ====
   wordchain: undefined;
-  // 커뮤니티(피드)
-  feedList: undefined;
-  feedDetail: {
-    feedId: string;
-  };
 }
 
 export interface ImpressionEvents {
+  // ==== 멤버 ====
+  memberCard: MemberCard;
+
+  // ==== 커뮤니티(피드) ====
   feedCard: {
     feedId?: string;
     category?: string;
     screen?: '멤버' | '기획경선 홈팝업' | 'TL리스트';
   };
-  memberCard: MemberCard;
+
+  // ==== 홈(광고) ====
   ads: { bannerId: number; pageUrl: string; timeStamp: string };
   adPopup: undefined;
 
-  // 기획경선 특집
-  balancegame: undefined;
+  // ==== 에스크 ====
   AskCard: {
     feedId: number;
   };
-
   askContentCard: {
     id: number;
     name: string;
   };
+
+  // ==== 기획경선 특집 ====
+  balancegame: undefined;
 }

--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -1,18 +1,7 @@
-import { string } from 'zod';
-
 type MemberCard = {
   id: number;
   name: string;
   screen?: 'recommended' | 'TL' | 'member';
-};
-
-type CommunityFeedData = {
-  categoryId: number;
-  title: string | null;
-  content: string;
-  isQuestion: boolean;
-  isBlindWriter: boolean;
-  images: string[];
 };
 
 export type UserProperties = {
@@ -238,6 +227,7 @@ export interface ClickEvents {
   TabAsk: {
     id: number;
     name: string;
+    hasRecentAsk: boolean;
   };
   TabProfile: {
     id: number;
@@ -247,6 +237,16 @@ export interface ClickEvents {
   AnswerUploadButton: undefined;
   AskLike: {
     feedId: number;
+  };
+
+  askContentCard: {
+    id: number;
+    name: string;
+    referral: string;
+  };
+  memberAskPreview: {
+    id: number;
+    name: string;
   };
 }
 
@@ -349,5 +349,10 @@ export interface ImpressionEvents {
   balancegame: undefined;
   AskCard: {
     feedId: number;
+  };
+
+  askContentCard: {
+    id: number;
+    name: string;
   };
 }

--- a/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/MemberDetail.tsx
@@ -73,6 +73,7 @@ const MemberDetail = ({ memberId }: MemberDetailProps) => {
         logClickEvent('TabAsk', {
           id: Number(memberId),
           name: profile.name,
+          hasRecentAsk: profile.hasRecentQuestion,
         });
       } else if (tab === 'profile') {
         logClickEvent('TabProfile', {

--- a/apps/playground/src/components/members/main/AskCard/AskCard.tsx
+++ b/apps/playground/src/components/members/main/AskCard/AskCard.tsx
@@ -4,38 +4,42 @@ import { fonts } from '@sopt-makers/fonts';
 import { IconUser } from '@sopt-makers/icons';
 import { Button } from '@sopt-makers/ui';
 
+import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 interface AskCardProps {
+  memberId: number;
   profileName: string;
   askContent: string;
   profileImageUrl?: string;
   onAnswerClick: () => void;
 }
 
-const AskCard = ({ profileName, askContent, profileImageUrl, onAnswerClick }: AskCardProps) => {
+const AskCard = ({ memberId, profileName, askContent, profileImageUrl, onAnswerClick }: AskCardProps) => {
   return (
-    <StyledContainer>
-      <StyledTopContainer>
-        <StyledAskTitleContainer>
-          {profileImageUrl ? (
-            <StyledAskProfileImage src={profileImageUrl} alt={`${profileName}님의 프로필 이미지`} />
-          ) : (
-            <StyledIconUser />
-          )}
-          <StyledAskTitle>
-            <StyledName>{profileName}</StyledName>님에게 온 에스크
-          </StyledAskTitle>
-        </StyledAskTitleContainer>
-        <StyledAskContents>{askContent}</StyledAskContents>
-      </StyledTopContainer>
+    <LoggingImpression eventKey='askContentCard' param={{ id: memberId, name: profileName }}>
+      <StyledContainer>
+        <StyledTopContainer>
+          <StyledAskTitleContainer>
+            {profileImageUrl ? (
+              <StyledAskProfileImage src={profileImageUrl} alt={`${profileName}님의 프로필 이미지`} />
+            ) : (
+              <StyledIconUser />
+            )}
+            <StyledAskTitle>
+              <StyledName>{profileName}</StyledName>님에게 온 에스크
+            </StyledAskTitle>
+          </StyledAskTitleContainer>
+          <StyledAskContents>{askContent}</StyledAskContents>
+        </StyledTopContainer>
 
-      <ButtonContainer>
-        <Button size='md' onClick={onAnswerClick} theme='black'>
-          답변 보러가기
-        </Button>
-      </ButtonContainer>
-    </StyledContainer>
+        <ButtonContainer>
+          <Button size='md' onClick={onAnswerClick} theme='black'>
+            답변 보러가기
+          </Button>
+        </ButtonContainer>
+      </StyledContainer>
+    </LoggingImpression>
   );
 };
 

--- a/apps/playground/src/components/members/main/AskCardList/AskCardList.tsx
+++ b/apps/playground/src/components/members/main/AskCardList/AskCardList.tsx
@@ -31,7 +31,7 @@ const AskCardList = () => {
 
   const { logClickEvent } = useEventLogger();
   const handleAnswerClick = (question: MembersQuestionType) => {
-    logClickEvent('askContentCard', { id: question.receiverId, name: question.receiverName, referral: 'ask_content' });
+    logClickEvent('askContentCard', { id: question.receiverId, name: question.receiverName });
     router.push({
       pathname: `/members/${question.receiverId}`,
       query: {

--- a/apps/playground/src/components/members/main/AskCardList/AskCardList.tsx
+++ b/apps/playground/src/components/members/main/AskCardList/AskCardList.tsx
@@ -8,6 +8,7 @@ import {
   useGetMembersQuestionsLatest,
 } from '@/api/endpoint/members/getMembersQuestionsLatest';
 import Carousel from '@/components/common/Carousel';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import AskCard from '../AskCard/AskCard';
@@ -28,7 +29,9 @@ const AskCardList = () => {
     return () => media.removeEventListener('change', handleChange);
   }, []);
 
+  const { logClickEvent } = useEventLogger();
   const handleAnswerClick = (question: MembersQuestionType) => {
+    logClickEvent('askContentCard', { id: question.receiverId, name: question.receiverName, referral: 'ask_content' });
     router.push({
       pathname: `/members/${question.receiverId}`,
       query: {
@@ -49,6 +52,7 @@ const AskCardList = () => {
           askData?.questions.map((question) => (
             <AskCard
               key={question.questionId}
+              memberId={question.receiverId}
               profileName={question.receiverName}
               askContent={question.content}
               profileImageUrl={question.receiverProfileImage ?? undefined}

--- a/apps/playground/src/components/members/main/MemberCard/index.tsx
+++ b/apps/playground/src/components/members/main/MemberCard/index.tsx
@@ -10,6 +10,7 @@ import type { QuestionPreview } from '@/api/endpoint_LEGACY/members/type';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { useVisibleBadges } from '@/components/members/main/hooks/useVisibleBadges';
 import CoffeeChatButton from '@/components/members/main/MemberCard/CoffeeChatButton';
 import IconCoffee from '@/public/icons/icon-coffee.svg';
@@ -57,6 +58,14 @@ const MemberCard = ({
   const onCoffeeChatButtonClick = (e: React.MouseEvent<Element, MouseEvent>) => {
     e.preventDefault();
     router.push(playgroundLink.coffeechatDetail(memberId));
+  };
+
+  const { logClickEvent } = useEventLogger();
+  const handleAskPreviewClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    // TODO: 에스크탭으로 페이지네이션 로직 추가
+    logClickEvent('memberAskPreview', { id: memberId, name: name });
   };
 
   return (
@@ -130,7 +139,7 @@ const MemberCard = ({
         )}
 
         {questionPreview && (
-          <StyledAskPreviewBubble>
+          <StyledAskPreviewBubble onClick={handleAskPreviewClick}>
             <Tag size='sm' shape='rect' variant='primary' type='solid'>
               ASK
             </Tag>


### PR DESCRIPTION
## 📋 작업 내용

- [x] 멤버 에스크 관련 앰플리튜드 로깅 추가
- [x] `events.ts` 리팩토링

## 📌 PR Point

- `click-memberAskPreview`, `click-askContentCard`, `impression-askContentCard` 이벤트 로깅 추가
- `click-TabAsk`에 `hasRecentAsk` 속성 추가
- `events.ts`에 각 이벤트들이 규칙없이 정의되어 있어서 알아보기가 불편했어요. 그래서 [notion](https://www.notion.so/sopt-makers/Data-Taxonomy-32c76042aac281339532ef97d753f2f6?source=copy_link)에 있는 Group 속성을 기반으로 도메인 별로 정리했어요.

## 📸 스크린샷
<img width="306" height="122" alt="image" src="https://github.com/user-attachments/assets/2aa6ecb5-d4c2-4ebc-9f86-6f51385fa6b2" />

- `click-memberAskPreview`

<br />

<img width="305" height="138" alt="image" src="https://github.com/user-attachments/assets/ee99ec7b-48f5-4d95-864c-4873763f6937" />

- `click-TabAsk`

<br />

<img width="297" height="256" alt="image" src="https://github.com/user-attachments/assets/5e23a13c-eb08-4f71-a575-b9d0b764b552" />

- `impression-askContentCard`

<br />

<img width="289" height="78" alt="image" src="https://github.com/user-attachments/assets/aa8ae7be-195a-4e7c-b465-482b2e1de502" />

- `click-askContentCard`
