### PR TITLE
feat: SP1 멤버 관련 앰플리튜드 로깅 추가

### DIFF
--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -98,6 +98,11 @@ export interface ClickEvents {
     name: string;
     recommendationType: 'SAME_PART' | 'SAME_CREW' | 'SAME_PROJECT' | 'SAME_UNIVERSITY' | 'SAME_GENERATION';
   };
+  memberRecommendCard: {
+    id: number;
+    name: string;
+    recommendationType: 'SAME_PART' | 'SAME_CREW' | 'SAME_MBTI' | 'SAME_UNIVERSITY' | 'SAME_GENERATION';
+  };
 
   // 프로필 편집
   editProfile: undefined;

--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -89,6 +89,10 @@ export interface ClickEvents {
     id: number;
     name: string;
   };
+  profileSameGroupCard: {
+    id: number;
+    name: string;
+  };
   // 프로필 편집
   editProfile: undefined;
 

--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -93,6 +93,12 @@ export interface ClickEvents {
     id: number;
     name: string;
   };
+  profileConnectionCard: {
+    id: number;
+    name: string;
+    recommendationType: 'SAME_PART' | 'SAME_CREW' | 'SAME_PROJECT' | 'SAME_UNIVERSITY' | 'SAME_GENERATION';
+  };
+
   // 프로필 편집
   editProfile: undefined;
 

--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -400,6 +400,20 @@ export interface ImpressionEvents {
     name: string;
   };
 
+  // ==== 추천 카드 ====
+  memberRecommendCard: {
+    id: number;
+    name: string;
+    recommendationType:
+      | 'SAME_PART'
+      | 'SAME_CREW'
+      | 'SAME_MBTI'
+      | 'SAME_UNIVERSITY'
+      | 'SAME_GENERATION'
+      | 'SAME_PROJECT';
+    screen: 'memberTab' | 'profile';
+  };
+
   // ==== 기획경선 특집 ====
   balancegame: undefined;
 }

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -13,11 +13,20 @@ import RecommendTypeChip from './RecommendTypeChip';
 type RecommendCardProps = Pick<
   RecommendMemberOfMe | RecommendMemberById,
   'profileImage' | 'name' | 'generation' | 'part' | 'recommendType'
->;
+> & {
+  handleConnectionCardClick?: () => void;
+};
 
-const MemberRecommendCard = ({ profileImage, name, generation, part, recommendType }: RecommendCardProps) => {
+const MemberRecommendCard = ({
+  profileImage,
+  name,
+  generation,
+  part,
+  recommendType,
+  handleConnectionCardClick,
+}: RecommendCardProps) => {
   return (
-    <StyledContainer>
+    <StyledContainer onClick={handleConnectionCardClick}>
       <StyledAvatarWrapper>
         {profileImage ? <StyledAvatar src={profileImage} alt={`${name}님의 프로필 이미지`} /> : <StyledDefaultAvatar />}
         <StyledChipOverlay>

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -10,12 +10,16 @@ import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import RecommendTypeChip from './RecommendTypeChip';
 
 // 두 API의 recommendType enum 값이 달라 유니온으로 수용
-type RecommendCardProps = Pick<
-  RecommendMemberOfMe | RecommendMemberById,
-  'profileImage' | 'name' | 'generation' | 'part' | 'recommendType'
->;
+interface Props {
+  member: Pick<
+    RecommendMemberOfMe | RecommendMemberById,
+    'profileImage' | 'name' | 'generation' | 'part' | 'recommendType'
+  >;
+}
 
-const MemberRecommendCard = ({ profileImage, name, generation, part, recommendType }: RecommendCardProps) => {
+const MemberRecommendCard = ({ member }: Props) => {
+  const { profileImage, name, generation, part, recommendType } = member;
+
   return (
     <StyledContainer>
       <StyledAvatarWrapper>

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -13,20 +13,11 @@ import RecommendTypeChip from './RecommendTypeChip';
 type RecommendCardProps = Pick<
   RecommendMemberOfMe | RecommendMemberById,
   'profileImage' | 'name' | 'generation' | 'part' | 'recommendType'
-> & {
-  handleConnectionCardClick?: () => void;
-};
+>;
 
-const MemberRecommendCard = ({
-  profileImage,
-  name,
-  generation,
-  part,
-  recommendType,
-  handleConnectionCardClick,
-}: RecommendCardProps) => {
+const MemberRecommendCard = ({ profileImage, name, generation, part, recommendType }: RecommendCardProps) => {
   return (
-    <StyledContainer onClick={handleConnectionCardClick}>
+    <StyledContainer>
       <StyledAvatarWrapper>
         {profileImage ? <StyledAvatar src={profileImage} alt={`${name}님의 프로필 이미지`} /> : <StyledDefaultAvatar />}
         <StyledChipOverlay>

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -39,13 +39,7 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
               param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
             >
               <Link href={playgroundLink.memberDetail(member.id)}>
-                <MemberRecommendCard
-                  name={member.name}
-                  profileImage={member.profileImage}
-                  generation={member.generation}
-                  part={member.part}
-                  recommendType={member.recommendType}
-                />
+                <MemberRecommendCard member={member} />
               </Link>
             </LoggingClick>
           </LoggingImpression>

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -35,13 +35,11 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
             param={{ id: member.id, name: member.name, recommendationType: member.recommendType, screen: 'profile' }}
           >
             <LoggingClick
-              key={member.id}
               eventKey='profileConnectionCard'
               param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
             >
-              <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+              <Link href={playgroundLink.memberDetail(member.id)}>
                 <MemberRecommendCard
-                  key={member.id}
                   name={member.name}
                   profileImage={member.profileImage}
                   generation={member.generation}

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -4,7 +4,9 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
 
+import type { RecommendMemberById } from '@/api/endpoint/members/getMemberRecommendById';
 import { useGetMemberRecommendById } from '@/api/endpoint/members/getMemberRecommendById';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -18,6 +20,15 @@ interface MemberRecommendSectionProps {
 const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps) => {
   const { data, refetch } = useGetMemberRecommendById(memberId);
   const memberRecommendData = data?.members.slice(0, 3);
+  const { logClickEvent } = useEventLogger();
+
+  const handleConnectionCardClick = (member: RecommendMemberById) => {
+    logClickEvent('profileConnectionCard', {
+      id: member.id,
+      name: member.name,
+      recommendationType: member.recommendType,
+    });
+  };
 
   return (
     <StyledSection>
@@ -35,6 +46,7 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
               generation={member.generation}
               part={member.part}
               recommendType={member.recommendType}
+              handleConnectionCardClick={() => handleConnectionCardClick(member)}
             />
           </Link>
         ))}

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 
 import { useGetMemberRecommendById } from '@/api/endpoint/members/getMemberRecommendById';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
+import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -28,22 +29,28 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
       </StyledSectionHeader>
       <StyledCardGrid>
         {memberRecommendData?.map((member) => (
-          <LoggingClick
+          <LoggingImpression
             key={member.id}
-            eventKey='profileConnectionCard'
-            param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+            eventKey='memberRecommendCard'
+            param={{ id: member.id, name: member.name, recommendationType: member.recommendType, screen: 'profile' }}
           >
-            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
-              <MemberRecommendCard
-                key={member.id}
-                name={member.name}
-                profileImage={member.profileImage}
-                generation={member.generation}
-                part={member.part}
-                recommendType={member.recommendType}
-              />
-            </Link>
-          </LoggingClick>
+            <LoggingClick
+              key={member.id}
+              eventKey='profileConnectionCard'
+              param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+            >
+              <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+                <MemberRecommendCard
+                  key={member.id}
+                  name={member.name}
+                  profileImage={member.profileImage}
+                  generation={member.generation}
+                  part={member.part}
+                  recommendType={member.recommendType}
+                />
+              </Link>
+            </LoggingClick>
+          </LoggingImpression>
         ))}
       </StyledCardGrid>
     </StyledSection>

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -4,9 +4,8 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
 
-import type { RecommendMemberById } from '@/api/endpoint/members/getMemberRecommendById';
 import { useGetMemberRecommendById } from '@/api/endpoint/members/getMemberRecommendById';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -20,15 +19,6 @@ interface MemberRecommendSectionProps {
 const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps) => {
   const { data, refetch } = useGetMemberRecommendById(memberId);
   const memberRecommendData = data?.members.slice(0, 3);
-  const { logClickEvent } = useEventLogger();
-
-  const handleConnectionCardClick = (member: RecommendMemberById) => {
-    logClickEvent('profileConnectionCard', {
-      id: member.id,
-      name: member.name,
-      recommendationType: member.recommendType,
-    });
-  };
 
   return (
     <StyledSection>
@@ -38,17 +28,22 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
       </StyledSectionHeader>
       <StyledCardGrid>
         {memberRecommendData?.map((member) => (
-          <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
-            <MemberRecommendCard
-              key={member.id}
-              name={member.name}
-              profileImage={member.profileImage}
-              generation={member.generation}
-              part={member.part}
-              recommendType={member.recommendType}
-              handleConnectionCardClick={() => handleConnectionCardClick(member)}
-            />
-          </Link>
+          <LoggingClick
+            key={member.id}
+            eventKey='profileConnectionCard'
+            param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+          >
+            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+              <MemberRecommendCard
+                key={member.id}
+                name={member.name}
+                profileImage={member.profileImage}
+                generation={member.generation}
+                part={member.part}
+                recommendType={member.recommendType}
+              />
+            </Link>
+          </LoggingClick>
         ))}
       </StyledCardGrid>
     </StyledSection>

--- a/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberCard.tsx
+++ b/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberCard.tsx
@@ -6,19 +6,11 @@ import { IconChevronRight, IconUser } from '@sopt-makers/icons';
 import type { MemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
-type SameActivityMemberCardProps = Omit<MemberGenerationPart, 'id'> & {
-  handleSameGroupClick: () => void;
-};
+type SameActivityMemberCardProps = Omit<MemberGenerationPart, 'id'>;
 
-const SameActivityMemberCard = ({
-  profileImage,
-  name,
-  generation,
-  part,
-  handleSameGroupClick,
-}: SameActivityMemberCardProps) => {
+const SameActivityMemberCard = ({ profileImage, name, generation, part }: SameActivityMemberCardProps) => {
   return (
-    <StyledContainer onClick={handleSameGroupClick}>
+    <StyledContainer>
       {profileImage ? <StyledAvatar src={profileImage} alt={`${name}님의 프로필 이미지`} /> : <StyledDefaultAvatar />}
       <StyledInfoWrapper>
         <StyledName>{name}</StyledName>

--- a/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberCard.tsx
+++ b/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberCard.tsx
@@ -6,11 +6,19 @@ import { IconChevronRight, IconUser } from '@sopt-makers/icons';
 import type { MemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
-type SameActivityMemberCardProps = Omit<MemberGenerationPart, 'id'>;
+type SameActivityMemberCardProps = Omit<MemberGenerationPart, 'id'> & {
+  handleSameGroupClick: () => void;
+};
 
-const SameActivityMemberCard = ({ profileImage, name, generation, part }: SameActivityMemberCardProps) => {
+const SameActivityMemberCard = ({
+  profileImage,
+  name,
+  generation,
+  part,
+  handleSameGroupClick,
+}: SameActivityMemberCardProps) => {
   return (
-    <StyledContainer>
+    <StyledContainer onClick={handleSameGroupClick}>
       {profileImage ? <StyledAvatar src={profileImage} alt={`${name}님의 프로필 이미지`} /> : <StyledDefaultAvatar />}
       <StyledInfoWrapper>
         <StyledName>{name}</StyledName>

--- a/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
+++ b/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
@@ -4,10 +4,9 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
 
-import type { MemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import { useGetMemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import type { SoptActivity } from '@/api/endpoint_LEGACY/members/type';
-import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import SameActivityMemberCard from './SameActivityMemberCard';
@@ -21,11 +20,6 @@ interface SamePartMemberSectionProps {
 const SamePartMemberSection = ({ memberId, name, recentSoptActivity }: SamePartMemberSectionProps) => {
   const isMakers = recentSoptActivity.team === '메이커스';
   const { data: memberGenerationPartData } = useGetMemberGenerationPart(memberId);
-  const { logClickEvent } = useEventLogger();
-
-  const handleSameGroupClick = (member: MemberGenerationPart) => {
-    logClickEvent('profileSameGroupCard', { id: member.id, name: member.name });
-  };
 
   return (
     <StyledSection>
@@ -34,15 +28,16 @@ const SamePartMemberSection = ({ memberId, name, recentSoptActivity }: SamePartM
       </StyledSectionTitle>
       <StyledCardGrid>
         {memberGenerationPartData?.members.map((member) => (
-          <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
-            <SameActivityMemberCard
-              profileImage={member.profileImage}
-              name={member.name}
-              generation={member.generation}
-              part={member.part}
-              handleSameGroupClick={() => handleSameGroupClick(member)}
-            />
-          </Link>
+          <LoggingClick key={member.id} eventKey='profileSameGroupCard' param={{ id: member.id, name: member.name }}>
+            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+              <SameActivityMemberCard
+                profileImage={member.profileImage}
+                name={member.name}
+                generation={member.generation}
+                part={member.part}
+              />
+            </Link>
+          </LoggingClick>
         ))}
       </StyledCardGrid>
     </StyledSection>

--- a/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
+++ b/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
@@ -4,8 +4,10 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import Link from 'next/link';
 
+import type { MemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import { useGetMemberGenerationPart } from '@/api/endpoint/members/getMemberGenerationPart';
 import type { SoptActivity } from '@/api/endpoint_LEGACY/members/type';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import SameActivityMemberCard from './SameActivityMemberCard';
@@ -19,6 +21,11 @@ interface SamePartMemberSectionProps {
 const SamePartMemberSection = ({ memberId, name, recentSoptActivity }: SamePartMemberSectionProps) => {
   const isMakers = recentSoptActivity.team === '메이커스';
   const { data: memberGenerationPartData } = useGetMemberGenerationPart(memberId);
+  const { logClickEvent } = useEventLogger();
+
+  const handleSameGroupClick = (member: MemberGenerationPart) => {
+    logClickEvent('profileSameGroupCard', { id: member.id, name: member.name });
+  };
 
   return (
     <StyledSection>
@@ -33,6 +40,7 @@ const SamePartMemberSection = ({ memberId, name, recentSoptActivity }: SamePartM
               name={member.name}
               generation={member.generation}
               part={member.part}
+              handleSameGroupClick={() => handleSameGroupClick(member)}
             />
           </Link>
         ))}

--- a/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
+++ b/apps/playground/src/components/members/detail/SameActivityMemberSection/SameActivityMemberSection.tsx
@@ -29,7 +29,7 @@ const SamePartMemberSection = ({ memberId, name, recentSoptActivity }: SamePartM
       <StyledCardGrid>
         {memberGenerationPartData?.members.map((member) => (
           <LoggingClick key={member.id} eventKey='profileSameGroupCard' param={{ id: member.id, name: member.name }}>
-            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+            <Link href={playgroundLink.memberDetail(member.id)}>
               <SameActivityMemberCard
                 profileImage={member.profileImage}
                 name={member.name}

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 import { useGetMemberRecommendOfMe } from '@/api/endpoint/members/getMemberRecommendOfMe';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -66,16 +67,22 @@ const MemberRecommendSection = () => {
       </StyledSectionHeader>
       <StyledCardGrid>
         {memberRecommendData?.map((member) => (
-          <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
-            <MemberRecommendCard
-              key={member.id}
-              name={member.name}
-              profileImage={member.profileImage}
-              generation={member.generation}
-              part={member.part}
-              recommendType={member.recommendType}
-            />
-          </Link>
+          <LoggingClick
+            key={member.id}
+            eventKey='memberRecommendCard'
+            param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+          >
+            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+              <MemberRecommendCard
+                key={member.id}
+                name={member.name}
+                profileImage={member.profileImage}
+                generation={member.generation}
+                part={member.part}
+                recommendType={member.recommendType}
+              />
+            </Link>
+          </LoggingClick>
         ))}
       </StyledCardGrid>
     </StyledSection>

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -78,13 +78,7 @@ const MemberRecommendSection = () => {
               param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
             >
               <Link href={playgroundLink.memberDetail(member.id)}>
-                <MemberRecommendCard
-                  name={member.name}
-                  profileImage={member.profileImage}
-                  generation={member.generation}
-                  part={member.part}
-                  recommendType={member.recommendType}
-                />
+                <MemberRecommendCard member={member} />
               </Link>
             </LoggingClick>
           </LoggingImpression>

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -74,13 +74,11 @@ const MemberRecommendSection = () => {
             param={{ id: member.id, name: member.name, recommendationType: member.recommendType, screen: 'memberTab' }}
           >
             <LoggingClick
-              key={member.id}
               eventKey='memberRecommendCard'
               param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
             >
-              <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+              <Link href={playgroundLink.memberDetail(member.id)}>
                 <MemberRecommendCard
-                  key={member.id}
                   name={member.name}
                   profileImage={member.profileImage}
                   generation={member.generation}

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 
 import { useGetMemberRecommendOfMe } from '@/api/endpoint/members/getMemberRecommendOfMe';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
+import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -67,22 +68,28 @@ const MemberRecommendSection = () => {
       </StyledSectionHeader>
       <StyledCardGrid>
         {memberRecommendData?.map((member) => (
-          <LoggingClick
+          <LoggingImpression
             key={member.id}
             eventKey='memberRecommendCard'
-            param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+            param={{ id: member.id, name: member.name, recommendationType: member.recommendType, screen: 'memberTab' }}
           >
-            <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
-              <MemberRecommendCard
-                key={member.id}
-                name={member.name}
-                profileImage={member.profileImage}
-                generation={member.generation}
-                part={member.part}
-                recommendType={member.recommendType}
-              />
-            </Link>
-          </LoggingClick>
+            <LoggingClick
+              key={member.id}
+              eventKey='memberRecommendCard'
+              param={{ id: member.id, name: member.name, recommendationType: member.recommendType }}
+            >
+              <Link key={member.id} href={playgroundLink.memberDetail(member.id)}>
+                <MemberRecommendCard
+                  key={member.id}
+                  name={member.name}
+                  profileImage={member.profileImage}
+                  generation={member.generation}
+                  part={member.part}
+                  recommendType={member.recommendType}
+                />
+              </Link>
+            </LoggingClick>
+          </LoggingImpression>
         ))}
       </StyledCardGrid>
     </StyledSection>


### PR DESCRIPTION
## 📋 작업 내용
- #62 
- [x] 상단 추천 멤버 카드 클릭 로깅 추가(Click-memberRecommendCard)
- [x] 프로필 내 하단 접점 추천 카드 클릭 로깅 추가(Click-profileConnectionCard)
- [x] 프로필 내 같은 기수 같은 파트 추천 카드 클릭 추가(Click-profileSameGroupCard)
- [x] 추천 카드 화면에 나타나질 때 로깅 추가(Impression-memberRecommendCard)

## 📌 PR Point

- 카드 컴포넌트에다가 직접 LoggingClick, LoggingImpression 컴포넌트를 주입한 게 아니라 상위 컴포넌트인 section, list 컴포넌트에서 주입하는 형태로 구현했어요. 상위에서 주입하는게 나은지, 카드 컴포넌트에 직접 추가하는게 나은지 봐주시면 감사하겠습니당

## 📸 스크린샷

로깅을 추가한 컴포넌트들 사진으로 첨부하겠습니다

> member/main
> 
> <img width="1366" height="206" alt="image" src="https://github.com/user-attachments/assets/bd1054b3-b045-4cd2-8973-7a927910d372" />

<br/>

> member/detail
> 
> <img width="810" height="151" alt="image" src="https://github.com/user-attachments/assets/02245bb8-1c12-4b43-937e-20b530dab649" />
> <br/>
> <img width="837" height="204" alt="image" src="https://github.com/user-attachments/assets/4d350ea7-588f-44fd-a481-c38bcc385bcc" />
