### PR TITLE
feat: 파트/기수 신청 멤버 버튼 및 모달 API 연결

### DIFF
--- a/apps/crew/package.json
+++ b/apps/crew/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write . --ignore-path ../../.prettierignore",
     "generate-types": "cat ./src/__generated__/schema1.d.ts ./src/__generated__/schema2.d.ts > ./src/__generated__/schema.d.ts",
     "generate-types-v1": "openapi-typescript https://crew.api.dev.sopt.org/api-docs-json -o ./src/__generated__/schema1.d.ts",
-    "generate-types-v2": "openapi-typescript https://crew.api.dev.sopt.org/api-docs/json -o ./src/__generated__/schema2.d.ts",
+    "generate-types-v2": "openapi-typescript https://crew-dev.sopt.org/api-docs/json -o ./src/__generated__/schema2.d.ts",
     "lint": "next lint",
     "start": "next start",
     "storybook": "storybook dev -p 6006",

--- a/apps/crew/package.json
+++ b/apps/crew/package.json
@@ -27,6 +27,7 @@
     "@nanostores/react": "^0.7.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@sentry/nextjs": "^7.0.0",
+    "@sopt-makers/fonts": "^2.0.2",
     "@sopt-makers/icons": "^1.1.0",
     "@sopt-makers/ui": "^2.10.2",
     "@sopt/constant": "workspace:*",

--- a/apps/crew/src/__generated__/schema2.d.ts
+++ b/apps/crew/src/__generated__/schema2.d.ts
@@ -12,23 +12,6 @@ export interface paths {
     /** 모임 게시글 삭제 */
     delete: operations['deletePost'];
   };
-  '/meeting/v2/{meetingId}': {
-    /**
-     * 모임 상세 조회
-     * @description 모임 상세 조회
-     */
-    get: operations['getMeetingById'];
-    /**
-     * 모임 수정
-     * @description 모임 내용을 수정합니다.
-     */
-    put: operations['updateMeeting'];
-    /**
-     * 모임 삭제
-     * @description 모임 삭제합니다.
-     */
-    delete: operations['deleteMeeting'];
-  };
   '/meeting/v2/{meetingId}/apply/status': {
     /**
      * 모임 지원자 상태 변경
@@ -111,6 +94,9 @@ export interface paths {
     /** 모임 생성 */
     post: operations['createMeeting'];
   };
+  '/meeting/v2/test/apply': {
+    post: operations['applyTestGeneralMeeting'];
+  };
   '/meeting/v2/apply': {
     /** 일반 모임 지원 */
     post: operations['applyGeneralMeeting'];
@@ -166,6 +152,23 @@ export interface paths {
     /** 솝맵 등록 api */
     post: operations['createSoptMap'];
   };
+  '/meeting/v2/{meetingId}': {
+    /**
+     * 모임 상세 조회
+     * @description 모임 상세 조회
+     */
+    get: operations['getMeetingById'];
+    /**
+     * 모임 삭제
+     * @description 모임 삭제합니다.
+     */
+    delete: operations['deleteMeeting'];
+    /**
+     * 모임 수정
+     * @description 모임 내용을 부분 수정합니다.
+     */
+    patch: operations['updateMeeting'];
+  };
   '/user/v2': {
     /** 전체 사용자 조회 */
     get: operations['getAllUser'];
@@ -204,6 +207,13 @@ export interface paths {
   '/post/v2/count': {
     /** 모임 게시글 개수 조회 */
     get: operations['getPostCount'];
+  };
+  '/meeting/v2/{meetingId}/members': {
+    /**
+     * 모임 내 같은 파트 참여 멤버 리스트 조회
+     * @description 조회자와 같은 파트 기준으로 참여중인 멤버 리스트를 조회합니다.
+     */
+    get: operations['getMeetingPartMembers'];
   };
   '/meeting/v2/{meetingId}/list': {
     /**
@@ -255,6 +265,13 @@ export interface paths {
      */
     get: operations['getAppliedMeetingInfo'];
   };
+  '/internal/meetings/related-user-ids/{userId}': {
+    /**
+     * [Internal] 모임에 함께 참여했던 유저 정보들 조회
+     * @description 플그 요청에 따른 맴버에 따라 크루 모임에 함께 참여했던 유저를 조회하기 위한 api
+     */
+    get: operations['getWithMeetingUserIds'];
+  };
   '/internal/meetings/post': {
     /**
      * [Internal] 모임 전체 조회
@@ -301,6 +318,13 @@ export interface paths {
      * @description 게시글 목록 페이지일 경우, ?category=POST  <br /> 모임 목록 페이지일 경우, ?category=MEETING
      */
     get: operations['getAdvertisement'];
+  };
+  '/advertisement/v2/meeting/top': {
+    /**
+     * 모임 상단 광고 조회
+     * @description 모임 탭 상단에 노출할 광고와 신청 모임 정보를 조회합니다.
+     */
+    get: operations['getMeetingTopAdvertisement'];
   };
   '/meeting/v2/{meetingId}/apply': {
     /** 모임 지원 취소 */
@@ -364,114 +388,6 @@ export interface components {
        * ]
        */
       images?: string[];
-    };
-    /** @description 모임 생성 및 수정 request body dto */
-    MeetingV2CreateAndUpdateMeetingBodyDto: {
-      /**
-       * @description 모임 제목
-       * @example 알고보면 쓸데있는 개발 프로세스
-       */
-      title: string;
-      /**
-       * @description 모임 이미지 리스트, 최대 6개
-       * @example [
-       *   "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"
-       * ]
-       */
-      files: string[];
-      /**
-       * @description 모임 카테고리
-       * @example 스터디
-       */
-      category: string;
-      /**
-       * @description 모집 기간 시작 날짜
-       * @example 2022.10.08
-       */
-      startDate: string;
-      /**
-       * @description 모집 기간 끝 날짜
-       * @example 2022.10.09
-       */
-      endDate: string;
-      /**
-       * Format: int32
-       * @description 모집 인원
-       * @example 5
-       */
-      capacity: number;
-      /**
-       * @description 모집 정보
-       * @example api 가 터졌다고? 깃이 터졌다고?
-       */
-      desc: string;
-      /**
-       * @description 진행 방식 소개
-       * @example 소요 시간 : 1시간 예상
-       */
-      processDesc?: string;
-      /**
-       * @description 모임 활동 시작 날짜
-       * @example 2022.10.29
-       */
-      mStartDate?: string;
-      /**
-       * @description 모임 활동 종료 날짜
-       * @example 2022.10.30
-       */
-      mEndDate?: string;
-      /**
-       * @description 개설자 소개
-       * @example 안녕하세요 기획 파트 000입니다
-       */
-      leaderDesc?: string;
-      /**
-       * @description 유의할 사항
-       * @example 유의할 사항
-       */
-      note?: string;
-      /**
-       * @description 멘토 필요 여부
-       * @example false
-       */
-      isMentorNeeded: boolean;
-      /**
-       * @description 활동기수만 지원 가능 여부
-       * @example false
-       */
-      canJoinOnlyActiveGeneration: boolean;
-      /**
-       * @description 대상 파트 목록
-       * @example [
-       *   "ANDROID",
-       *   "IOS"
-       * ]
-       */
-      joinableParts: ('PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'SERVER' | 'WEB')[];
-      /**
-       * @description 공동 모임장 userId (크루에서 사용하는 userId)
-       * @example [
-       *   1304,
-       *   1305
-       * ]
-       */
-      coLeaderUserIds?: number[];
-      /**
-       * @description 환영 메시지 타입 리스트
-       * @example [
-       *   "YB 환영",
-       *   "OB 환영"
-       * ]
-       */
-      welcomeMessageTypes?: string[];
-      /**
-       * @description 모임 키워드 타입 리스트
-       * @example [
-       *   "운동",
-       *   "자기계발"
-       * ]
-       */
-      meetingKeywordTypes?: string[];
     };
     /** @description 모임 지원자 상태 변경 request body dto */
     ApplyV2UpdateStatusBodyDto: {
@@ -747,6 +663,125 @@ export interface components {
       exposeEndDate?: string;
       noticeSecretKey?: string;
     };
+    /**
+     * @description 참여 정보
+     * @example {
+     *   "meetingType": "온라인",
+     *   "meetingFrequency": "적당히"
+     * }
+     */
+    MeetingJoinInfo: {
+      /** @enum {string} */
+      meetingType?: '온라인' | '오프라인' | '온-오프';
+      /** @enum {string} */
+      meetingFrequency?: '가볍게' | '적당히' | '집중형';
+    };
+    /** @description 모임 생성 request body dto */
+    MeetingV2CreateMeetingBodyDto: {
+      /**
+       * @description 모임 제목
+       * @example 알고보면 쓸데있는 개발 프로세스
+       */
+      title: string;
+      /**
+       * @description 모임 부제목
+       * @example 평양 냉면 스터디 2기입니다.
+       */
+      subTitle: string;
+      /**
+       * @description 모임 이미지 리스트, 최대 6개
+       * @example [
+       *   "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"
+       * ]
+       */
+      files: string[];
+      /**
+       * @description 모임 카테고리
+       * @example 스터디
+       */
+      category: string;
+      /**
+       * @description 모집 기간 시작 날짜
+       * @example 2022.10.08
+       */
+      startDate: string;
+      /**
+       * @description 모집 기간 끝 날짜
+       * @example 2022.10.09
+       */
+      endDate: string;
+      /**
+       * Format: int32
+       * @description 모집 인원
+       * @example 5
+       */
+      capacity: number;
+      /**
+       * @description 모집 정보
+       * @example api 가 터졌다고? 깃이 터졌다고?
+       */
+      desc: string;
+      /**
+       * @description 진행 방식 소개
+       * @example 소요 시간 : 1시간 예상
+       */
+      processDesc?: string;
+      /**
+       * @description 모임 활동 시작 날짜
+       * @example 2022.10.29
+       */
+      mStartDate?: string;
+      /**
+       * @description 모임 활동 종료 날짜
+       * @example 2022.10.30
+       */
+      mEndDate?: string;
+      /**
+       * @description 개설자 소개
+       * @example 안녕하세요 기획 파트 000입니다
+       */
+      leaderDesc?: string;
+      /**
+       * @description 유의할 사항
+       * @example 유의할 사항
+       */
+      note?: string;
+      /**
+       * @description 멘토 필요 여부
+       * @example false
+       */
+      isMentorNeeded: boolean;
+      /**
+       * @description 활동기수만 지원 가능 여부
+       * @example false
+       */
+      canJoinOnlyActiveGeneration: boolean;
+      joinInfo: components['schemas']['MeetingJoinInfo'];
+      /**
+       * @description 대상 파트 목록
+       * @example [
+       *   "ANDROID",
+       *   "IOS"
+       * ]
+       */
+      joinableParts: ('PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'SERVER' | 'WEB')[];
+      /**
+       * @description 공동 모임장 userId (크루에서 사용하는 userId)
+       * @example [
+       *   1304,
+       *   1305
+       * ]
+       */
+      coLeaderUserIds?: number[];
+      /**
+       * @description 모임 키워드 타입 리스트
+       * @example [
+       *   "운동",
+       *   "자기계발"
+       * ]
+       */
+      meetingKeywordTypes?: string[];
+    };
     /** @description 일반 모임 생성 응답 Dto */
     MeetingV2CreateMeetingResponseDto: {
       /**
@@ -965,6 +1000,112 @@ export interface components {
       identifiedPwd?: string;
       originalCallEmoji?: string;
       updateCallEmoji?: string;
+    };
+    /** @description 모임 부분 수정 request body dto */
+    MeetingV2UpdateMeetingBodyDto: {
+      /**
+       * @description 모임 제목
+       * @example 알고보면 쓸데있는 개발 프로세스
+       */
+      title?: string;
+      /**
+       * @description 모임 부제목
+       * @example 평양 냉면 스터디 2기입니다.
+       */
+      subTitle?: string;
+      /**
+       * @description 모임 이미지 리스트, 최대 6개
+       * @example [
+       *   "https://makers-web-img.s3.ap-northeast-2.amazonaws.com/meeting/2023/04/12/7bd87736-b557-4b26-a0d5-9b09f1f1d7df"
+       * ]
+       */
+      files?: string[];
+      /**
+       * @description 모임 카테고리
+       * @example 스터디
+       */
+      category?: string;
+      /**
+       * @description 모집 기간 시작 날짜
+       * @example 2022.10.08
+       */
+      startDate?: string;
+      /**
+       * @description 모집 기간 끝 날짜
+       * @example 2022.10.09
+       */
+      endDate?: string;
+      /**
+       * Format: int32
+       * @description 모집 인원
+       * @example 5
+       */
+      capacity?: number;
+      /**
+       * @description 모집 정보
+       * @example api 가 터졌다고? 깃이 터졌다고?
+       */
+      desc?: string;
+      /**
+       * @description 진행 방식 소개
+       * @example 소요 시간 : 1시간 예상
+       */
+      processDesc?: string;
+      /**
+       * @description 모임 활동 시작 날짜
+       * @example 2022.10.29
+       */
+      mStartDate?: string;
+      /**
+       * @description 모임 활동 종료 날짜
+       * @example 2022.10.30
+       */
+      mEndDate?: string;
+      /**
+       * @description 개설자 소개
+       * @example 안녕하세요 기획 파트 000입니다
+       */
+      leaderDesc?: string;
+      /**
+       * @description 유의할 사항
+       * @example 유의할 사항
+       */
+      note?: string;
+      /**
+       * @description 멘토 필요 여부
+       * @example false
+       */
+      isMentorNeeded?: boolean;
+      /**
+       * @description 활동기수만 지원 가능 여부
+       * @example false
+       */
+      canJoinOnlyActiveGeneration?: boolean;
+      joinInfo?: components['schemas']['MeetingJoinInfo'];
+      /**
+       * @description 대상 파트 목록
+       * @example [
+       *   "ANDROID",
+       *   "IOS"
+       * ]
+       */
+      joinableParts?: ('PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'SERVER' | 'WEB')[];
+      /**
+       * @description 공동 모임장 userId (크루에서 사용하는 userId)
+       * @example [
+       *   1304,
+       *   1305
+       * ]
+       */
+      coLeaderUserIds?: number[];
+      /**
+       * @description 환영 메시지 타입 리스트
+       * @example [
+       *   "YB 환영",
+       *   "OB 환영"
+       * ]
+       */
+      welcomeMessageTypes?: string[];
     };
     /** @description 전체 사용자 조회 응답 Dto */
     UserV2GetAllUserDto: {
@@ -1554,6 +1695,11 @@ export interface components {
        */
       title: string;
       /**
+       * @description 모임 부제목
+       * @example 모임 부제목입니다
+       */
+      subTitle?: string;
+      /**
        * Format: int32
        * @description 대상 기수
        * @example 33
@@ -1594,6 +1740,7 @@ export interface components {
        * @example false
        */
       isMentorNeeded: boolean;
+      joinInfo?: components['schemas']['MeetingJoinInfo'];
       /**
        * Format: date-time
        * @description 모임 모집 시작일
@@ -1773,6 +1920,11 @@ export interface components {
        */
       title: string;
       /**
+       * @description 모임 부제목
+       * @example 모임 부제목입니다.
+       */
+      subTitle?: string;
+      /**
        * @description 모임 카테고리
        * @example 스터디
        */
@@ -1838,6 +1990,8 @@ export interface components {
        * @example false
        */
       canJoinOnlyActiveGeneration: boolean;
+      joinInfo?: components['schemas']['MeetingJoinInfo'];
+      participatingPartInfo?: components['schemas']['MeetingV2ParticipatingPartInfoDto'];
       /**
        * Format: int32
        * @description 개설 기수
@@ -1904,6 +2058,61 @@ export interface components {
       welcomeMessageTypes: string[];
       /** @description 모임 키워드 타입 목록 */
       meetingKeywordTypes: string[];
+    };
+    /** @description 조회자와 같은 파트 참여 정보 */
+    MeetingV2ParticipatingPartInfoDto: {
+      /**
+       * @description 조회자 기준 파트
+       * @example 서버
+       */
+      part?: string;
+      /**
+       * Format: int32
+       * @description 참여중인 같은 파트 인원수
+       * @example 3
+       */
+      participantCount?: number;
+      /**
+       * @description 활동기수 여부
+       * @example true
+       */
+      isActiveGeneration?: boolean;
+      /**
+       * Format: int32
+       * @description 참여 정보 기준 기수
+       * @example 38
+       */
+      activeGeneration?: number;
+      /**
+       * @description 조건에 맞는 신청중/대기중 유저 이름 리스트
+       * @example [
+       *   "이지훈",
+       *   "김효준"
+       * ]
+       */
+      memberNames?: string[];
+    };
+    /** @description 모임 내 같은 파트 참여 멤버 리스트 조회 dto */
+    MeetingV2GetMeetingPartMembersResponseDto: {
+      /**
+       * @description 조회자 기준 파트
+       * @example 서버
+       */
+      part?: string;
+      /**
+       * Format: int32
+       * @description 참여중인 같은 파트 인원수
+       * @example 2
+       */
+      participantCount?: number;
+      /**
+       * @description 참여중인 같은 파트 멤버 이름 리스트
+       * @example [
+       *   "이지훈",
+       *   "김효준"
+       * ]
+       */
+      memberNames?: string[];
     };
     /** @description 모임 신청자 객체 Dto */
     ApplicantDto: {
@@ -2064,6 +2273,11 @@ export interface components {
        */
       title: string;
       /**
+       * @description 모임 부제목
+       * @example 모임 부제목입니다
+       */
+      subTitle?: string;
+      /**
        * @description 모임 사진
        * @example [url] 형식
        */
@@ -2073,6 +2287,7 @@ export interface components {
        * @example 스터디
        */
       category: string;
+      joinInfo?: components['schemas']['MeetingJoinInfo'];
       /**
        * @description 모임 활성 여부
        * @example true
@@ -2102,6 +2317,11 @@ export interface components {
        * @example 모임 제목입니다1
        */
       title: string;
+      /**
+       * @description 모임 부제목
+       * @example 모임 부제목입니다
+       */
+      subTitle?: string;
       /**
        * @description 모임 카테고리
        * @example 스터디
@@ -2384,6 +2604,14 @@ export interface components {
       /** @description 모임 이미지 url */
       imgUrl?: string;
     };
+    InternalUserWithMeetingUsersResponseDto: {
+      currentGenerationUserIds?: components['schemas']['UserOrgIdDto'][];
+      pastGenerationUserIds?: components['schemas']['UserOrgIdDto'][];
+    };
+    UserOrgIdDto: {
+      /** Format: int32 */
+      orgUserId?: number;
+    };
     /** @description [Internal] 모임 피드 작성시 모임 전체 조회 응답 Dto */
     InternalMeetingForWritingPostDto: {
       /**
@@ -2396,7 +2624,7 @@ export interface components {
        * @example 스터디
        * @enum {string}
        */
-      category?: 'STUDY' | 'LECTURE' | 'FLASH' | 'EVENT' | 'SEMINAR' | '스터디' | '행사' | '세미나' | '번쩍' | '강연';
+      category?: 'STUDY' | 'LECTURE' | 'FLASH' | 'EVENT' | 'SEMINAR' | '스터디' | '행사' | '세미나' | ' 번쩍' | ' 강연';
       /**
        * @description 모임 이미지
        * @example [url 형식]
@@ -2870,6 +3098,69 @@ export interface components {
       /** @description 광고 구좌 이미지 리스트 */
       advertisements: components['schemas']['AdvertisementGetDto'][];
     };
+    /** @description 모임 상단 광고 조회 응답 Dto */
+    AdvertisementMeetingTopGetResponseDto: {
+      /**
+       * @description 배너 노출 여부
+       * @example true
+       */
+      isDisplay: boolean;
+      /**
+       * @description 배너 이벤트 타입
+       * @example SOPKATHON
+       * @enum {string}
+       */
+      eventType?: 'SOPKATHON' | 'NETWORKING';
+      /**
+       * Format: int32
+       * @description 배너 id
+       * @example 3
+       */
+      advertisementId?: number;
+      /**
+       * @description [Desktop] 배너 이미지 url
+       * @example [pc 버전 url 형식]
+       */
+      desktopImageUrl?: string;
+      /**
+       * @description [Mobile] 배너 이미지 url
+       * @example [mobile 버전 url 형식]
+       */
+      mobileImageUrl?: string;
+      /**
+       * @description 달력 이미지 url
+       * @example [달력 이미지 url 형식]
+       */
+      calendarImageUrl?: string;
+      title?: components['schemas']['AdvertisementMeetingTopTitleDto'];
+      /**
+       * @description 배너 부제목
+       * @example 우리만의 해커톤, 누구보다 빠르게 신청하세요!
+       */
+      subTitle?: string;
+      /** @description 배너 링크 1 */
+      bannerLink1?: string;
+      /** @description 배너 링크 2 */
+      bannerLink2?: string;
+    };
+    /** @description 모임 상단 광고 제목 Dto */
+    AdvertisementMeetingTopTitleDto: {
+      /**
+       * @description 배너 제목 prefix
+       * @example 5월 4일
+       */
+      prefix?: string;
+      /**
+       * @description 배너 제목 highlight
+       * @example 솝커톤 신청
+       */
+      highlight?: string;
+      /**
+       * @description 배너 제목 suffix
+       * @example  OPEN!
+       */
+      suffix?: string;
+    };
     SlackEmojiEventDeleteRequestDto: {
       identifiedPwd?: string;
       callEmoji?: string;
@@ -2881,6 +3172,8 @@ export interface components {
   headers: never;
   pathItems: never;
 }
+
+export type $defs = Record<string, never>;
 
 export type external = Record<string, never>;
 
@@ -2900,7 +3193,9 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다 */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 수정 */
@@ -2923,9 +3218,13 @@ export interface operations {
         };
       };
       /** @description "게시글이 없습니다." or "이미지는 최대 10개까지만 업로드 가능합니다." */
-      400: never;
+      400: {
+        content: never;
+      };
       /** @description 권한이 없습니다. */
-      403: never;
+      403: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 삭제 */
@@ -2937,67 +3236,17 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      200: never;
-      /** @description 모임이 없습니다. */
-      400: never;
-      /** @description 권한이 없습니다. */
-      403: never;
-    };
-  };
-  /**
-   * 모임 상세 조회
-   * @description 모임 상세 조회
-   */
-  getMeetingById: {
-    parameters: {
-      path: {
-        meetingId: number;
-      };
-    };
-    responses: {
-      /** @description 모임 상세 조회 성공 */
       200: {
-        content: {
-          'application/json;charset=UTF-8': components['schemas']['MeetingV2GetMeetingByIdResponseDto'];
-        };
+        content: never;
       };
       /** @description 모임이 없습니다. */
-      400: never;
-    };
-  };
-  /**
-   * 모임 수정
-   * @description 모임 내용을 수정합니다.
-   */
-  updateMeeting: {
-    parameters: {
-      path: {
-        meetingId: number;
+      400: {
+        content: never;
       };
-    };
-    requestBody: {
-      content: {
-        'application/json;charset=UTF-8': components['schemas']['MeetingV2CreateAndUpdateMeetingBodyDto'];
+      /** @description 권한이 없습니다. */
+      403: {
+        content: never;
       };
-    };
-    responses: {
-      /** @description OK */
-      200: never;
-    };
-  };
-  /**
-   * 모임 삭제
-   * @description 모임 삭제합니다.
-   */
-  deleteMeeting: {
-    parameters: {
-      path: {
-        meetingId: number;
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: never;
     };
   };
   /**
@@ -3017,7 +3266,9 @@ export interface operations {
     };
     responses: {
       /** @description OK */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** 번쩍 모임 상세 조회 */
@@ -3035,7 +3286,9 @@ export interface operations {
         };
       };
       /** @description 번쩍 모임이 없습니다. */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 번쩍 모임 수정 */
@@ -3052,9 +3305,13 @@ export interface operations {
     };
     responses: {
       /** @description meetingId: 10, tagId: 5 */
-      200: never;
+      200: {
+        content: never;
+      };
       /** @description VALIDATION_EXCEPTION */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 댓글 수정 */
@@ -3087,7 +3344,9 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      204: never;
+      204: {
+        content: never;
+      };
     };
   };
   /** 솝맵 상세 조회 api */
@@ -3158,11 +3417,17 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      204: never;
+      204: {
+        content: never;
+      };
       /** @description 권한 없음 */
-      403: never;
+      403: {
+        content: never;
+      };
       /** @description 솝맵을 찾을 수 없음 */
-      404: never;
+      404: {
+        content: never;
+      };
     };
   };
   /** 솝맵 추천하기 api */
@@ -3201,7 +3466,9 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** 이모지 이벤트 생성 */
@@ -3281,7 +3548,9 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다. */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 작성 */
@@ -3299,9 +3568,13 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다. */
-      400: never;
+      400: {
+        content: never;
+      };
       /** @description 권한이 없습니다. */
-      403: never;
+      403: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 조회수 증가 */
@@ -3335,7 +3608,9 @@ export interface operations {
         };
       };
       /** @description "게시글이 없습니다." or "이미 신고한 게시글입니다." */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 좋아요 토글 */
@@ -3363,7 +3638,9 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** 공지사항 조회 */
@@ -3386,7 +3663,9 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /**
@@ -3456,7 +3735,7 @@ export interface operations {
   createMeeting: {
     requestBody: {
       content: {
-        'application/json;charset=UTF-8': components['schemas']['MeetingV2CreateAndUpdateMeetingBodyDto'];
+        'application/json;charset=UTF-8': components['schemas']['MeetingV2CreateMeetingBodyDto'];
       };
     };
     responses: {
@@ -3467,7 +3746,30 @@ export interface operations {
         };
       };
       /** @description "이미지 파일이 없습니다." or "한 개 이상의 파트를 입력해주세요" or "프로필을 입력해주세요" */
-      400: never;
+      400: {
+        content: never;
+      };
+    };
+  };
+  applyTestGeneralMeeting: {
+    parameters: {
+      header: {
+        'X-API-TEST': string;
+        'X-USER-ID': number;
+      };
+    };
+    requestBody: {
+      content: {
+        'application/json;charset=UTF-8': components['schemas']['MeetingV2ApplyMeetingDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          'application/json;charset=UTF-8': components['schemas']['MeetingV2ApplyMeetingResponseDto'];
+        };
+      };
     };
   };
   /** 일반 모임 지원 */
@@ -3485,7 +3787,9 @@ export interface operations {
         };
       };
       /** @description "모임이 없습니다" or "기수/파트를 설정해주세요" or "정원이 꽉찼습니다" or "활동 기수가 아닙니다" or "지원 가능한 파트가 아닙니다" or "지원 가능한 기간이 아닙니다" */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /**
@@ -3587,7 +3891,9 @@ export interface operations {
         };
       };
       /** @description VALIDATION_EXCEPTION */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 댓글 리스트 조회 */
@@ -3677,7 +3983,9 @@ export interface operations {
     };
     responses: {
       /** @description 성공 */
-      200: never;
+      200: {
+        content: never;
+      };
     };
   };
   /** 로그인/회원가입 */
@@ -3690,9 +3998,13 @@ export interface operations {
         };
       };
       /** @description 유효하지 않는 토큰입니다. */
-      401: never;
+      401: {
+        content: never;
+      };
       /** @description 크루 서버 또는 플레이그라운드 서버 오류입니다. */
-      500: never;
+      500: {
+        content: never;
+      };
     };
   };
   /** 솝맵 목록 조회/검색/필터링 api */
@@ -3751,6 +4063,68 @@ export interface operations {
       };
     };
   };
+  /**
+   * 모임 상세 조회
+   * @description 모임 상세 조회
+   */
+  getMeetingById: {
+    parameters: {
+      path: {
+        meetingId: number;
+      };
+    };
+    responses: {
+      /** @description 모임 상세 조회 성공 */
+      200: {
+        content: {
+          'application/json;charset=UTF-8': components['schemas']['MeetingV2GetMeetingByIdResponseDto'];
+        };
+      };
+      /** @description 모임이 없습니다. */
+      400: {
+        content: never;
+      };
+    };
+  };
+  /**
+   * 모임 삭제
+   * @description 모임 삭제합니다.
+   */
+  deleteMeeting: {
+    parameters: {
+      path: {
+        meetingId: number;
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
+  /**
+   * 모임 수정
+   * @description 모임 내용을 부분 수정합니다.
+   */
+  updateMeeting: {
+    parameters: {
+      path: {
+        meetingId: number;
+      };
+    };
+    requestBody: {
+      content: {
+        'application/json;charset=UTF-8': components['schemas']['MeetingV2UpdateMeetingBodyDto'];
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        content: never;
+      };
+    };
+  };
   /** 전체 사용자 조회 */
   getAllUser: {
     responses: {
@@ -3772,7 +4146,9 @@ export interface operations {
         };
       };
       /** @description 해당 유저가 없는 경우 */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /**
@@ -3810,7 +4186,9 @@ export interface operations {
         };
       };
       /** @description 내가 속한 모임 리스트가 없는 경우 */
-      204: never;
+      204: {
+        content: never;
+      };
     };
   };
   /** 내가 신청한 모임 조회 */
@@ -3839,7 +4217,9 @@ export interface operations {
         };
       };
       /** @description 유효하지 않는 토큰입니다. */
-      401: never;
+      401: {
+        content: never;
+      };
     };
   };
   /** 프로퍼티/홈 컨텐츠 조회 */
@@ -3852,7 +4232,9 @@ export interface operations {
         };
       };
       /** @description 유효하지 않는 토큰입니다. */
-      401: never;
+      401: {
+        content: never;
+      };
     };
   };
   /** 모임 게시글 개수 조회 */
@@ -3870,7 +4252,32 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다 */
-      400: never;
+      400: {
+        content: never;
+      };
+    };
+  };
+  /**
+   * 모임 내 같은 파트 참여 멤버 리스트 조회
+   * @description 조회자와 같은 파트 기준으로 참여중인 멤버 리스트를 조회합니다.
+   */
+  getMeetingPartMembers: {
+    parameters: {
+      path: {
+        meetingId: number;
+      };
+    };
+    responses: {
+      /** @description 모임 내 같은 파트 참여 멤버 리스트 조회 성공 */
+      200: {
+        content: {
+          'application/json;charset=UTF-8': components['schemas']['MeetingV2GetMeetingPartMembersResponseDto'];
+        };
+      };
+      /** @description 모임이 없습니다. */
+      400: {
+        content: never;
+      };
     };
   };
   /**
@@ -3913,7 +4320,9 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다. */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /**
@@ -3978,7 +4387,9 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다. */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
   /**
@@ -4040,7 +4451,9 @@ export interface operations {
         };
       };
       /** @description 모임이 없습니다. */
-      204: never;
+      204: {
+        content: never;
+      };
     };
   };
   /**
@@ -4101,6 +4514,29 @@ export interface operations {
       200: {
         content: {
           'application/json;charset=UTF-8': components['schemas']['InternalUserAppliedMeetingResponseDto'];
+        };
+      };
+    };
+  };
+  /**
+   * [Internal] 모임에 함께 참여했던 유저 정보들 조회
+   * @description 플그 요청에 따른 맴버에 따라 크루 모임에 함께 참여했던 유저를 조회하기 위한 api
+   */
+  getWithMeetingUserIds: {
+    parameters: {
+      path: {
+        /**
+         * @description 찾고자 하는 userId
+         * @example 10
+         */
+        userId: number;
+      };
+    };
+    responses: {
+      /** @description 조회 성공 */
+      200: {
+        content: {
+          'application/json;charset=UTF-8': components['schemas']['InternalUserWithMeetingUsersResponseDto'];
         };
       };
     };
@@ -4287,7 +4723,7 @@ export interface operations {
   getAdvertisement: {
     parameters: {
       query: {
-        category: 'POST' | 'MEETING';
+        category: 'POST' | 'MEETING' | 'MEETING_TOP';
       };
     };
     responses: {
@@ -4295,6 +4731,25 @@ export interface operations {
       200: {
         content: {
           'application/json;charset=UTF-8': components['schemas']['AdvertisementsGetResponseDto'];
+        };
+      };
+    };
+  };
+  /**
+   * 모임 상단 광고 조회
+   * @description 모임 탭 상단에 노출할 광고와 신청 모임 정보를 조회합니다.
+   */
+  getMeetingTopAdvertisement: {
+    parameters: {
+      query?: {
+        eventType?: 'SOPKATHON' | 'NETWORKING';
+      };
+    };
+    responses: {
+      /** @description 성공 */
+      200: {
+        content: {
+          'application/json;charset=UTF-8': components['schemas']['AdvertisementMeetingTopGetResponseDto'];
         };
       };
     };
@@ -4308,9 +4763,13 @@ export interface operations {
     };
     responses: {
       /** @description 지원 취소 완료 */
-      200: never;
+      200: {
+        content: never;
+      };
       /** @description 존재하지 않는 모임 신청입니다. */
-      400: never;
+      400: {
+        content: never;
+      };
     };
   };
 }

--- a/apps/crew/src/__generated__/schema2.d.ts
+++ b/apps/crew/src/__generated__/schema2.d.ts
@@ -49,14 +49,6 @@ export interface paths {
     /** 유저 관심 키워드 설정 */
     post: operations['updateUserInterestedKeyword'];
   };
-  '/slack/emoji': {
-    /** 이모지 이벤트 생성 */
-    post: operations['addEmoji'];
-    /** 이모지 이벤트 삭제 */
-    delete: operations['deleteEmoji'];
-    /** 이모지 이벤트 업데이트 */
-    patch: operations['updateEmoji'];
-  };
   '/post/v2': {
     /** 모임 게시글 목록 조회 */
     get: operations['getPosts'];
@@ -210,8 +202,8 @@ export interface paths {
   };
   '/meeting/v2/{meetingId}/members': {
     /**
-     * 모임 내 같은 파트 참여 멤버 리스트 조회
-     * @description 조회자와 같은 파트 기준으로 참여중인 멤버 리스트를 조회합니다.
+     * 모임 내 같은 파트/기수 멤버 리스트 조회
+     * @description 조회자 기준 파트/기수 조건에 맞는 참여중인 멤버 리스트를 조회합니다.
      */
     get: operations['getMeetingPartMembers'];
   };
@@ -558,16 +550,6 @@ export interface components {
     };
     UpdateUserInterestKeywordRequestDto: {
       keywords?: string[];
-    };
-    SlackEmojiEventRequestDto: {
-      identifiedPwd?: string;
-      callEmoji?: string;
-      username?: string;
-      userSlackId?: string;
-      team?: string;
-      /** Format: int32 */
-      generation?: number;
-      templateCd?: string;
     };
     /** @description 게시물 생성 request body dto */
     PostV2CreatePostBodyDto: {
@@ -995,11 +977,6 @@ export interface components {
        * @example https://map~~~~
        */
       kakaoLink?: string;
-    };
-    SlackUpdateEmojiEventRequestDto: {
-      identifiedPwd?: string;
-      originalCallEmoji?: string;
-      updateCallEmoji?: string;
     };
     /** @description 모임 부분 수정 request body dto */
     MeetingV2UpdateMeetingBodyDto: {
@@ -1951,6 +1928,11 @@ export interface components {
        */
       capacity: number;
       /**
+       * Format: date-time
+       * @description 모임 생성 시간
+       */
+      createdTimestamp: string;
+      /**
        * @description 모임 소개
        * @example 모임 소개 입니다.
        */
@@ -1991,7 +1973,6 @@ export interface components {
        */
       canJoinOnlyActiveGeneration: boolean;
       joinInfo?: components['schemas']['MeetingJoinInfo'];
-      participatingPartInfo?: components['schemas']['MeetingV2ParticipatingPartInfoDto'];
       /**
        * Format: int32
        * @description 개설 기수
@@ -2059,8 +2040,8 @@ export interface components {
       /** @description 모임 키워드 타입 목록 */
       meetingKeywordTypes: string[];
     };
-    /** @description 조회자와 같은 파트 참여 정보 */
-    MeetingV2ParticipatingPartInfoDto: {
+    /** @description 모임 내 같은 파트/기수 참여 멤버 리스트 조회 dto */
+    MeetingV2GetMeetingPartMembersResponseDto: {
       /**
        * @description 조회자 기준 파트
        * @example 서버
@@ -2068,8 +2049,8 @@ export interface components {
       part?: string;
       /**
        * Format: int32
-       * @description 참여중인 같은 파트 인원수
-       * @example 3
+       * @description 조건에 맞는 신청중/대기중 유저 수
+       * @example 2
        */
       participantCount?: number;
       /**
@@ -2084,35 +2065,29 @@ export interface components {
        */
       activeGeneration?: number;
       /**
-       * @description 조건에 맞는 신청중/대기중 유저 이름 리스트
+       * @description 유저 리스트의 index id
+       * @example [
+       *   1,
+       *   2
+       * ]
+       */
+      memberIds?: number[];
+      /**
+       * @description 유저 이름 리스트
        * @example [
        *   "이지훈",
        *   "김효준"
        * ]
        */
       memberNames?: string[];
-    };
-    /** @description 모임 내 같은 파트 참여 멤버 리스트 조회 dto */
-    MeetingV2GetMeetingPartMembersResponseDto: {
       /**
-       * @description 조회자 기준 파트
-       * @example 서버
-       */
-      part?: string;
-      /**
-       * Format: int32
-       * @description 참여중인 같은 파트 인원수
-       * @example 2
-       */
-      participantCount?: number;
-      /**
-       * @description 참여중인 같은 파트 멤버 이름 리스트
+       * @description 유저 프로필 이미지 리스트
        * @example [
-       *   "이지훈",
-       *   "김효준"
+       *   "https://example.com/profile.png",
+       *   null
        * ]
        */
-      memberNames?: string[];
+      memberProfileImages?: string[];
     };
     /** @description 모임 신청자 객체 Dto */
     ApplicantDto: {
@@ -3086,7 +3061,7 @@ export interface components {
        * @description 광고 구좌 링크
        * @example https://www.naver.com
        */
-      advertisementLink: string;
+      advertisementLink?: string;
       /**
        * Format: date-time
        * @description 광고 게시 시작일
@@ -3160,10 +3135,6 @@ export interface components {
        * @example  OPEN!
        */
       suffix?: string;
-    };
-    SlackEmojiEventDeleteRequestDto: {
-      identifiedPwd?: string;
-      callEmoji?: string;
     };
   };
   responses: never;
@@ -3468,54 +3439,6 @@ export interface operations {
       /** @description 성공 */
       200: {
         content: never;
-      };
-    };
-  };
-  /** 이모지 이벤트 생성 */
-  addEmoji: {
-    requestBody: {
-      content: {
-        'application/json;charset=UTF-8': components['schemas']['SlackEmojiEventRequestDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json;charset=UTF-8': string;
-        };
-      };
-    };
-  };
-  /** 이모지 이벤트 삭제 */
-  deleteEmoji: {
-    requestBody: {
-      content: {
-        'application/json;charset=UTF-8': components['schemas']['SlackEmojiEventDeleteRequestDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json;charset=UTF-8': string;
-        };
-      };
-    };
-  };
-  /** 이모지 이벤트 업데이트 */
-  updateEmoji: {
-    requestBody: {
-      content: {
-        'application/json;charset=UTF-8': components['schemas']['SlackUpdateEmojiEventRequestDto'];
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json;charset=UTF-8': string;
-        };
       };
     };
   };
@@ -4258,8 +4181,8 @@ export interface operations {
     };
   };
   /**
-   * 모임 내 같은 파트 참여 멤버 리스트 조회
-   * @description 조회자와 같은 파트 기준으로 참여중인 멤버 리스트를 조회합니다.
+   * 모임 내 같은 파트/기수 멤버 리스트 조회
+   * @description 조회자 기준 파트/기수 조건에 맞는 참여중인 멤버 리스트를 조회합니다.
    */
   getMeetingPartMembers: {
     parameters: {
@@ -4268,7 +4191,7 @@ export interface operations {
       };
     };
     responses: {
-      /** @description 모임 내 같은 파트 참여 멤버 리스트 조회 성공 */
+      /** @description 모임 내 같은 파트/기수 멤버 리스트 조회 성공 */
       200: {
         content: {
           'application/json;charset=UTF-8': components['schemas']['MeetingV2GetMeetingPartMembersResponseDto'];

--- a/apps/crew/src/api/meeting/MeetingQueryKey.ts
+++ b/apps/crew/src/api/meeting/MeetingQueryKey.ts
@@ -6,6 +6,7 @@ const MeetingQueryKey = {
   detail: (meetingId: number) => [...MeetingQueryKey.all(), meetingId] as const,
   memberList: (meetingId: string, params?: GetMeetingMemberList['request']) =>
     [...MeetingQueryKey.all(), 'memberList', meetingId, params] as const,
+  partMembers: (meetingId: number) => [...MeetingQueryKey.all(), 'partMembers', meetingId] as const,
   recommendList: (meetingIds: number[]) => [...MeetingQueryKey.all(), 'recommendList', meetingIds] as const,
 };
 

--- a/apps/crew/src/api/meeting/index.ts
+++ b/apps/crew/src/api/meeting/index.ts
@@ -3,6 +3,7 @@ import type {
   GetMeetingList,
   GetMeetingMemberCSV,
   GetMeetingMemberList,
+  GetMeetingPartMembers,
   GetRecommendMeetingList,
   PostMeeting,
   PostMeetingApplication,
@@ -77,6 +78,12 @@ export const postEventApplication = async (
   body: PostMeetingApplication['request'],
 ): Promise<PostMeetingApplication['response']> => {
   return (await api.post<PostMeetingApplication['response']>(`/meeting/v2/apply/undefined`, body)).data;
+};
+
+export const getMeetingPartMembers = async ({
+  meetingId,
+}: GetMeetingPartMembers['request']): Promise<GetMeetingPartMembers['response']> => {
+  return (await api.get<GetMeetingPartMembers['response']>(`/meeting/v2/${meetingId}/members`)).data;
 };
 
 export const getRecommendMeetingList = async ({ meetingIds = [] }: { meetingIds: number[] }) => {

--- a/apps/crew/src/api/meeting/query.ts
+++ b/apps/crew/src/api/meeting/query.ts
@@ -1,5 +1,11 @@
 import MeetingQueryKey from '@api/meeting/MeetingQueryKey';
-import type { GetMeeting, GetMeetingList, GetMeetingMemberList, GetRecommendMeetingList } from '@api/meeting/type';
+import type {
+  GetMeeting,
+  GetMeetingList,
+  GetMeetingMemberList,
+  GetMeetingPartMembers,
+  GetRecommendMeetingList,
+} from '@api/meeting/type';
 import { parsePartLabelToValue, parseStatusToNumber } from '@api/meeting/util';
 import { ACTIVE_GENERATION } from '@constant/activeGeneration';
 import { APPROVAL_STATUS_ENGLISH, APPROVAL_STATUS_KOREAN_TO_ENGLISH, RECRUITMENT_STATUS } from '@constant/option';
@@ -17,7 +23,7 @@ import {
 } from '@hook/queryString/custom';
 import { queryOptions } from '@tanstack/react-query';
 
-import { getMeeting, getMeetingList, getMeetingMemberList, getRecommendMeetingList } from '.';
+import { getMeeting, getMeetingList, getMeetingMemberList, getMeetingPartMembers, getRecommendMeetingList } from '.';
 
 export const useMeetingListQueryOption = () => {
   const { value: category } = useCategoryParams();
@@ -96,6 +102,14 @@ export const useMeetingMemberListQueryOption = ({ meetingId }: { meetingId: stri
     queryFn: () => {
       return getMeetingMemberList({ params, meetingId });
     },
+    enabled: !!meetingId,
+  });
+};
+
+export const useMeetingPartMembersQueryOption = ({ meetingId }: { meetingId: number }) => {
+  return queryOptions<GetMeetingPartMembers['response']>({
+    queryKey: MeetingQueryKey.partMembers(meetingId),
+    queryFn: () => getMeetingPartMembers({ meetingId }),
     enabled: !!meetingId,
   });
 };

--- a/apps/crew/src/api/meeting/serialize.ts
+++ b/apps/crew/src/api/meeting/serialize.ts
@@ -10,13 +10,15 @@ export const serializeMeetingData = (formData: FormType): PostMeeting['request']
 
   return {
     title: formData.title,
+    // TODO: @진혁 - API 스키마 수정
+    subTitle: '',
+    joinInfo: {},
     files: formData.files,
     category: formData.category.value,
     startDate: formData.dateRange[0] ?? '',
     endDate: formData.dateRange[1] ?? '',
     capacity: formData.capacity,
     desc: formData.detail.desc,
-    // TODO: @진혁 - 스키마 수정되면 제거 필요
     processDesc: '',
     mStartDate: '',
     mEndDate: '',
@@ -26,7 +28,6 @@ export const serializeMeetingData = (formData: FormType): PostMeeting['request']
     canJoinOnlyActiveGeneration: formData.detail.canJoinOnlyActiveGeneration ?? false,
     joinableParts: refinedParts,
     coLeaderUserIds: formData.detail.coLeader?.map((user) => user.userId) ?? [],
-    welcomeMessageTypes: formData.welcomeMessageTypes === null ? undefined : formData.welcomeMessageTypes,
     meetingKeywordTypes: formData.meetingKeywordTypes === null ? undefined : formData.meetingKeywordTypes,
   };
 };

--- a/apps/crew/src/api/meeting/type.ts
+++ b/apps/crew/src/api/meeting/type.ts
@@ -41,3 +41,8 @@ export type GetMeetingMemberCSV = {
   request: paths['/meeting/v2/{meetingId}/list/csv']['get']['parameters']['query'];
   response: paths['/meeting/v2/{meetingId}/list/csv']['get']['responses']['200']['content']['application/json;charset=UTF-8'];
 };
+
+export type GetMeetingPartMembers = {
+  request: paths['/meeting/v2/{meetingId}/members']['get']['parameters']['path'];
+  response: paths['/meeting/v2/{meetingId}/members']['get']['responses']['200']['content']['application/json;charset=UTF-8'];
+};

--- a/apps/crew/src/domain/detail/Information/constant.tsx
+++ b/apps/crew/src/domain/detail/Information/constant.tsx
@@ -24,16 +24,23 @@ export const MeetingDetailList = (detailData: GetMeeting['response']) => [
                 {tag}
               </Chip>
             ))}
-            {detailData?.welcomeMessageTypes.map((tag) => (
+            {detailData?.welcomeMessageTypes?.map((tag) => (
               <Chip key={tag} style={{ boxShadow: 'none' }}>
                 {tag}
               </Chip>
             ))}
+            {/* TODO: 필드명 확인 후 주석 해제
+            {detailData?.participationTagTypes?.map((tag) => (
+              <Chip key={tag} style={{ boxShadow: 'none' }}>
+                {tag}
+              </Chip>
+            ))} */}
           </STarget>
           <SDescription>{parseTextToLink(detailData?.desc)}</SDescription>
         </>
       );
     },
+    // TODO: participationTagTypes 필드명 확인 후 isValid에도 추가
     isValid: detailData?.meetingKeywordTypes.length || detailData?.welcomeMessageTypes.length || detailData?.desc,
   },
   {

--- a/apps/crew/src/domain/detail/Information/constant.tsx
+++ b/apps/crew/src/domain/detail/Information/constant.tsx
@@ -20,18 +20,18 @@ export const MeetingDetailList = (detailData: GetMeeting['response']) => [
         <>
           <STarget>
             {detailData?.meetingKeywordTypes.map((tag) => (
-              <Chip key={tag} style={{ boxShadow: 'none' }} active>
+              <Chip key={tag} style={{ boxShadow: 'none' }}>
                 {tag}
               </Chip>
             ))}
             {detailData?.welcomeMessageTypes?.map((tag) => (
-              <Chip key={tag} style={{ boxShadow: 'none' }}>
+              <Chip key={tag} style={{ boxShadow: 'none' }} active>
                 {tag}
               </Chip>
             ))}
             {detailData?.joinInfo &&
               (Object.values(detailData.joinInfo) as (string | undefined)[]).filter(Boolean).map((tag) => (
-                <Chip key={tag} style={{ boxShadow: 'none' }}>
+                <Chip key={tag} style={{ boxShadow: 'none' }} active>
                   {`#${tag}`}
                 </Chip>
               ))}

--- a/apps/crew/src/domain/detail/Information/constant.tsx
+++ b/apps/crew/src/domain/detail/Information/constant.tsx
@@ -29,19 +29,22 @@ export const MeetingDetailList = (detailData: GetMeeting['response']) => [
                 {tag}
               </Chip>
             ))}
-            {/* TODO: 필드명 확인 후 주석 해제
-            {detailData?.participationTagTypes?.map((tag) => (
-              <Chip key={tag} style={{ boxShadow: 'none' }}>
-                {tag}
-              </Chip>
-            ))} */}
+            {detailData?.joinInfo &&
+              (Object.values(detailData.joinInfo) as (string | undefined)[]).filter(Boolean).map((tag) => (
+                <Chip key={tag} style={{ boxShadow: 'none' }}>
+                  {`#${tag}`}
+                </Chip>
+              ))}
           </STarget>
           <SDescription>{parseTextToLink(detailData?.desc)}</SDescription>
         </>
       );
     },
-    // TODO: participationTagTypes 필드명 확인 후 isValid에도 추가
-    isValid: detailData?.meetingKeywordTypes.length || detailData?.welcomeMessageTypes.length || detailData?.desc,
+    isValid:
+      detailData?.meetingKeywordTypes.length ||
+      detailData?.welcomeMessageTypes?.length ||
+      detailData?.joinInfo ||
+      detailData?.desc,
   },
   {
     key: '활동 기간',

--- a/apps/crew/src/domain/detail/MeetingController/MeetingAbout.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/MeetingAbout.tsx
@@ -11,6 +11,7 @@ const MeetingAbout = ({ detailData }: { detailData: GetMeeting['response'] }) =>
     title,
     status,
     startDate,
+    subTitle,
     endDate,
     user: { orgId: hostId, name: hostName, profileImage: hostProfileImage },
     category,
@@ -30,8 +31,7 @@ const MeetingAbout = ({ detailData }: { detailData: GetMeeting['response'] }) =>
         <span>{category}</span>
         {title}
       </h1>
-      {/* TODO: subtitle api response로 변경 */}
-      <SSubTitle>AI 시대 살아남는 디자이너가 되기 위한 피그마 스터디</SSubTitle>
+      <SSubTitle>{subTitle}</SSubTitle>
       <SHostWrapper>
         <ProfileAnchor
           profileData={{

--- a/apps/crew/src/domain/detail/MeetingController/MeetingAbout.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/MeetingAbout.tsx
@@ -2,6 +2,7 @@ import type { GetMeeting } from '@api/meeting/type';
 import MentorTooltip from '@domain/detail/MeetingController/MentorTooltip';
 import ProfileAnchor from '@domain/detail/MeetingController/ProfileAnchor';
 import RecruitmentStatusTag from '@shared/Tag/RecruitmentStatusTag';
+import { fontsObject } from '@sopt-makers/fonts';
 import dayjs from 'dayjs';
 import { styled } from 'stitches.config';
 
@@ -29,6 +30,8 @@ const MeetingAbout = ({ detailData }: { detailData: GetMeeting['response'] }) =>
         <span>{category}</span>
         {title}
       </h1>
+      {/* TODO: subtitle api response로 변경 */}
+      <SSubTitle>AI 시대 살아남는 디자이너가 되기 위한 피그마 스터디</SSubTitle>
       <SHostWrapper>
         <ProfileAnchor
           profileData={{
@@ -72,11 +75,27 @@ const SAbout = styled('div', {
 
     'fontAg': '34_bold_140',
     'color': '$gray10',
-    'mb': '$20',
 
     '@media (max-width: 768px)': {
       fontStyle: 'H3',
     },
+  },
+});
+
+const SSubTitle = styled('p', {
+  // TODO: mds 적용
+  ...fontsObject.BODY_1_18_M,
+
+  'color': '$gray200',
+  'mb': '$20',
+
+  '@media (max-width: 1023px)': {
+    ...fontsObject.BODY_2_16_R,
+  },
+
+  '@mobile (max-width: 767px)': {
+    ...fontsObject.BODY_3_14_M,
+    mb: '$16',
   },
 });
 

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
@@ -1,30 +1,28 @@
+import type { GetMeetingPartMembers } from '@api/meeting/type';
 import { styled } from 'stitches.config';
 
-import type { paths } from '@/__generated__/schema2';
-
-import RecruitmentStatusList from '../RecruitmentStatusModalContent/RecruitmentStatusList';
-
-// TODO: API 연결 시 파트 신청 멤버 API 응답 타입으로 교체
-type AppliedInfo =
-  paths['/meeting/v2/{meetingId}']['get']['responses']['200']['content']['application/json;charset=UTF-8']['appliedInfo'];
-
 interface PartStatusModalContentProps {
-  appliedInfo: AppliedInfo;
+  partMembersData: GetMeetingPartMembers['response'];
 }
 
-const PartStatusModalContent = ({ appliedInfo }: PartStatusModalContentProps) => {
-  const total = appliedInfo.length;
+const PartStatusModalContent = ({ partMembersData }: PartStatusModalContentProps) => {
+  const memberNames = partMembersData.memberNames ?? [];
+  const total = partMembersData.participantCount ?? memberNames.length;
 
   return (
     <>
-      {total > 0 ? (
-        <SRecruitmentStatusListWrapper>
-          <RecruitmentStatusList recruitmentStatusList={appliedInfo} />
-        </SRecruitmentStatusListWrapper>
+      {memberNames.length > 0 ? (
+        <SListWrapper>
+          <SList>
+            {memberNames.map((name, idx) => (
+              <SItem key={idx}>{name}</SItem>
+            ))}
+          </SList>
+        </SListWrapper>
       ) : (
         <SEmptyText>신청자가 없습니다.</SEmptyText>
       )}
-      {total > 0 && (
+      {memberNames.length > 0 && (
         <SModalBottom>
           <STotal>총 {total}명 신청</STotal>
         </SModalBottom>
@@ -35,11 +33,56 @@ const PartStatusModalContent = ({ appliedInfo }: PartStatusModalContentProps) =>
 
 export default PartStatusModalContent;
 
-const SRecruitmentStatusListWrapper = styled('div', {
+const SListWrapper = styled('div', {
   'padding': '$24 $24 0 $24',
 
   '@tablet': {
     padding: '$0',
+  },
+});
+
+const SList = styled('div', {
+  'display': 'grid',
+  'gridTemplateColumns': 'repeat(2, 1fr)',
+  'gap': '$12',
+  'padding': '0 $24',
+  'height': '$219',
+  'overflowY': 'scroll',
+
+  '@tablet': {
+    gap: '$8',
+    padding: '0 $20',
+    height: '$160',
+  },
+
+  '@mobile': {
+    gridTemplateColumns: '1fr',
+  },
+
+  '&::-webkit-scrollbar': {
+    width: '$6',
+  },
+
+  '&::-webkit-scrollbar-thumb': {
+    height: '$125',
+    background: '$gray200',
+    borderRadius: '6px',
+  },
+});
+
+const SItem = styled('div', {
+  'flexType': 'verticalCenter',
+  'height': '$64',
+  'padding': '$16 $20',
+  'borderRadius': '12px',
+  'backgroundColor': '$gray700',
+  'color': '$gray10',
+  'fontAg': '16_semibold_100',
+
+  '@tablet': {
+    height: '$48',
+    padding: '$11 $12',
+    fontAg: '14_medium_100',
   },
 });
 

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
@@ -1,0 +1,75 @@
+import { styled } from 'stitches.config';
+
+import type { paths } from '@/__generated__/schema2';
+
+import RecruitmentStatusList from '../RecruitmentStatusModalContent/RecruitmentStatusList';
+
+// TODO: API 연결 시 파트 신청 멤버 API 응답 타입으로 교체
+type AppliedInfo =
+  paths['/meeting/v2/{meetingId}']['get']['responses']['200']['content']['application/json;charset=UTF-8']['appliedInfo'];
+
+interface PartStatusModalContentProps {
+  appliedInfo: AppliedInfo;
+}
+
+const PartStatusModalContent = ({ appliedInfo }: PartStatusModalContentProps) => {
+  const total = appliedInfo.length;
+
+  return (
+    <>
+      {total > 0 ? (
+        <SRecruitmentStatusListWrapper>
+          <RecruitmentStatusList recruitmentStatusList={appliedInfo} />
+        </SRecruitmentStatusListWrapper>
+      ) : (
+        <SEmptyText>신청자가 없습니다.</SEmptyText>
+      )}
+      {total > 0 && (
+        <SModalBottom>
+          <STotal>총 {total}명 신청</STotal>
+        </SModalBottom>
+      )}
+    </>
+  );
+};
+
+export default PartStatusModalContent;
+
+const SRecruitmentStatusListWrapper = styled('div', {
+  'padding': '$24 $24 0 $24',
+
+  '@tablet': {
+    padding: '$0',
+  },
+});
+
+const SEmptyText = styled('p', {
+  'flexType': 'center',
+  'width': '100%',
+  'height': '$280',
+  'color': '$gray400',
+  'fontAg': '18_semibold_100',
+
+  '@tablet': {
+    height: '$184',
+    fontAg: '14_medium_100',
+  },
+});
+
+const SModalBottom = styled('div', {
+  'margin': '$24 $42 $44 $30',
+  'flexType': 'verticalCenter',
+
+  '@tablet': {
+    margin: '$16 $20 $24 $20',
+  },
+});
+
+const STotal = styled('p', {
+  'color': '$gray400',
+  'fontAg': '16_medium_100',
+
+  '@tablet': {
+    fontAg: '12_medium_100',
+  },
+});

--- a/apps/crew/src/domain/detail/MeetingController/ProfileAnchor.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/ProfileAnchor.tsx
@@ -41,7 +41,7 @@ const SProfileAnchor = styled('a', {
   'justifyContent': 'center',
   'alignItems': 'center',
   'gap': '14px',
-  '@media (max-width: 414px)': {
+  '@media (max-width: 767px)': {
     padding: '5px 8px',
     gap: '6px',
     br: '6.25px',
@@ -54,11 +54,11 @@ const SProfileAnchor = styled('a', {
     'objectFit': 'cover',
 
     'background': '$gray700',
-    '@media (max-width: 768px)': {
+    '@media (max-width: 1023px)': {
       width: '$32',
       height: '$32',
     },
-    '@media (max-width: 414px)': {
+    '@media (max-width: 767px)': {
       width: '$20',
       height: '$20',
     },
@@ -68,11 +68,11 @@ const SProfileAnchor = styled('a', {
     'width': '$48',
     'height': '$48',
 
-    '@media (max-width: 768px)': {
+    '@media (max-width: 1023px)': {
       width: '$32',
       height: '$32',
     },
-    '@media (max-width: 414px)': {
+    '@media (max-width: 767px)': {
       width: '$20',
       height: '$20',
     },
@@ -82,10 +82,10 @@ const SProfileAnchor = styled('a', {
     ...fontsObject.TITLE_3_24_SB,
     'fontWeight': 500,
 
-    '@media (max-width: 768px)': {
+    '@media (max-width: 1023px)': {
       fontStyle: 'T5',
     },
-    '@media (max-width: 414px)': {
+    '@media (max-width: 767px)': {
       ...fontsObject.LABEL_5_11_SB,
     },
   },

--- a/apps/crew/src/domain/detail/MeetingController/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/index.tsx
@@ -88,7 +88,10 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
     setModalTitle(`모집 현황 (${CAPACITY(detailData)})`);
   };
 
-  const partLabel = partMembersData?.part ? `${partMembersData.part} 파트 신청 멤버` : '신청 멤버';
+  const isActiveGeneration = partMembersData?.isActiveGeneration ?? true;
+  const partLabel = isActiveGeneration
+    ? `${partMembersData?.part} 파트 신청 멤버`
+    : `${partMembersData?.activeGeneration}기 신청 멤버`;
 
   const handlePartStatusModal = () => {
     handleDefaultModalOpen();
@@ -278,14 +281,15 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
             <SPartStatusButton onClick={handlePartStatusModal}>
               <span>
                 <SFireEmoji>🔥 </SFireEmoji>
-                {partMembersData?.part ? (
+                {isActiveGeneration ? (
                   <>
-                    <SPartName>{partMembersData.part} 파트</SPartName> {partMembersData.participantCount ?? 0}명
-                    <SApplyingText> 신청중</SApplyingText>
+                    <SPartName>{partMembersData?.part} 파트</SPartName> {partMembersData?.participantCount ?? 0}명
+                    <SApplyingText> 신청 중</SApplyingText>
                   </>
                 ) : (
                   <>
-                    {partMembersData?.participantCount ?? 0}명<SApplyingText> 신청 중</SApplyingText>
+                    {partMembersData?.activeGeneration}기 멤버 {partMembersData?.participantCount ?? 0}명
+                    <SApplyingText> 신청 중</SApplyingText>
                   </>
                 )}
               </span>

--- a/apps/crew/src/domain/detail/MeetingController/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/index.tsx
@@ -15,9 +15,11 @@ import { ERecruitmentStatus } from '@constant/option';
 import { CAPACITY } from '@domain/detail/MeetingController/constant';
 import FlashAbout from '@domain/detail/MeetingController/FlashAbout';
 import MeetingAbout from '@domain/detail/MeetingController/MeetingAbout';
+import { useDisplay } from '@hook/useDisplay';
 import useModal from '@hook/useModal';
 import DefaultModal from '@shared/modal/DefaultModal';
 import { playgroundLink } from '@sopt/constant';
+import { fontsObject } from '@sopt-makers/fonts';
 import { useDialog } from '@sopt-makers/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { AxiosResponse } from 'axios';
@@ -263,13 +265,22 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
           <MeetingAbout detailData={detailData as GetMeeting['response']} />
         )}
         <div>
-          <SStatusButton onClick={handleRecruitmentStatusModal}>
-            <div>
-              <span>모집 현황</span>
-              <span>{CAPACITY(detailData)}</span>
-            </div>
-            <ArrowSmallRightIcon />
-          </SStatusButton>
+          <SStatusButtonWrapper>
+            <SPartStatusButton>
+              <span>
+                <SFireEmoji>🔥 </SFireEmoji>
+                <SPartName>디자인</SPartName> 파트 2명<SApplyingText> 신청중</SApplyingText>
+              </span>
+              <ArrowSmallRightIcon />
+            </SPartStatusButton>
+            <SStatusButton onClick={handleRecruitmentStatusModal}>
+              <div>
+                <span>모집 현황</span>
+                <span>{CAPACITY(detailData)}</span>
+              </div>
+              <ArrowSmallRightIcon />
+            </SStatusButton>
+          </SStatusButtonWrapper>
           {!isHost && (
             <SGuestButton
               disabled={!isRecruiting || isSubmitting}
@@ -324,12 +335,90 @@ const SPanelWrapper = styled('div', {
   'borderBottom': `2px solid $gray700`,
   'mb': '$40',
 
-  '@mobile': {
+  '@media (max-width: 767px)': {
     display: 'block',
     paddingBottom: '0',
     borderBottom: 'none',
     mb: '$64',
   },
+});
+
+const SStatusButtonWrapper = styled('div', {
+  'display': 'flex',
+  'flexDirection': 'column',
+  'gap': '$8',
+  'mb': '$16',
+
+  '@media (max-width: 767px)': {
+    flexDirection: 'row',
+    mt: '$36',
+    mb: '$10',
+  },
+});
+
+const SPartStatusButton = styled('button', {
+  'outline': 'solid 1px $gray700',
+  'display': 'grid',
+  'gridTemplateColumns': '1fr auto 1fr',
+  'alignItems': 'center',
+  'width': '$300',
+  'height': '$34',
+  'borderRadius': '999px',
+  'backgroundColor': '$gray800',
+  'padding': '0 $16',
+  'color': '$gray10',
+
+  '& > span': {
+    gridColumn: 2,
+    ...fontsObject.BODY_2_16_R,
+    whiteSpace: 'nowrap',
+  },
+
+  '& > svg': {
+    gridColumn: 3,
+    justifySelf: 'end',
+  },
+
+  // 모바일: flex + SStatusButton과 동일한 UI, 오른쪽 배치
+  '@media (max-width: 767px)': {
+    'outline': 'none',
+    'display': 'flex',
+    'flex': 1,
+    'height': '$46',
+    'width': 'auto',
+    'borderRadius': '8px',
+    'padding': '$13 0',
+    'justifyContent': 'center',
+    'order': 2,
+
+    '& > span': {
+      gridColumn: 'auto',
+      ...fontsObject.LABEL_3_14_SB,
+      whiteSpace: 'normal',
+      mr: '$6',
+      color: '$white',
+    },
+
+    '& > svg': {
+      gridColumn: 'auto',
+      justifySelf: 'auto',
+      ml: '$2',
+    },
+  },
+});
+
+const SFireEmoji = styled('span', {
+  '@media (max-width: 767px)': { display: 'none' },
+});
+
+const SPartName = styled('span', {
+  'color': '$orange400',
+  'fontWeight': 'bold',
+  '@media (max-width: 767px)': { color: 'inherit' },
+});
+
+const SApplyingText = styled('span', {
+  '@media (max-width: 767px)': { display: 'none' },
 });
 
 const Button = styled('button', {
@@ -343,19 +432,20 @@ const SStatusButton = styled(Button, {
   'flexType': 'verticalCenter',
   'justifyContent': 'space-between',
   'padding': '$21 $20',
-  'mb': '$16',
   'backgroundColor': '$gray800',
-  'fontAg': '18_semibold_100',
+  ...fontsObject.LABEL_1_18_SB,
 
-  '@mobile': {
-    width: '100%',
+  '@media (max-width: 767px)': {
+    flex: 1,
     height: '$46',
     padding: '$13 0',
-    mt: '$32',
-    mb: '$10',
+    ...fontsObject.LABEL_3_14_SB,
+
     textAlign: 'center',
     justifyContent: 'center',
     fontStyle: 'T5',
+
+    order: 1,
 
     svg: {
       ml: '$2',
@@ -372,11 +462,12 @@ const SGuestButton = styled(Button, {
   'display': 'flex',
   'justifyContent': 'center',
   'alignItems': 'center',
-  'fontAg': '20_bold_100',
+  ...fontsObject.LABEL_1_18_SB,
+
   'padding': '$20 0',
   'textAlign': 'center',
   'color': '$gray950',
-  '@mobile': {
+  '@media (max-width: 767px)': {
     width: '100%',
     height: '$46',
     fontStyle: 'T5',

--- a/apps/crew/src/domain/detail/MeetingController/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/index.tsx
@@ -7,6 +7,7 @@ import {
   usePostEventApplicationMutation,
   usePostMeetingApplicationMutation,
 } from '@api/meeting/mutation';
+import { useMeetingPartMembersQueryOption } from '@api/meeting/query';
 import type { GetMeeting } from '@api/meeting/type';
 import { useUserProfileQueryOption } from '@api/user/query';
 import ArrowSmallRightIcon from '@assets/svg/arrow_small_right.svg';
@@ -64,6 +65,7 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
 
   const { open: dialogOpen, close: dialogClose } = useDialog();
   const { data: me } = useQuery(useUserProfileQueryOption());
+  const { data: partMembersData } = useQuery(useMeetingPartMembersQueryOption({ meetingId: Number(meetingId) }));
   const queryClient = useQueryClient();
   const router = useRouter();
   const isRecruiting = status === ERecruitmentStatus.RECRUITING;
@@ -86,13 +88,11 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
     setModalTitle(`모집 현황 (${CAPACITY(detailData)})`);
   };
 
-  // TODO: API 연결 후 실제 활동 여부 및 파트명/기수로 교체
-  const isActiveUser = true;
+  const partLabel = partMembersData?.part ? `${partMembersData.part} 파트 신청 멤버` : '신청 멤버';
 
   const handlePartStatusModal = () => {
-    const title = isActiveUser ? '디자인 파트 신청 멤버' : '38기 신청 멤버';
     handleDefaultModalOpen();
-    setModalTitle(title);
+    setModalTitle(partLabel);
   };
 
   const handleHostModalOpen = () => {
@@ -278,13 +278,14 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
             <SPartStatusButton onClick={handlePartStatusModal}>
               <span>
                 <SFireEmoji>🔥 </SFireEmoji>
-                {isActiveUser ? (
+                {partMembersData?.part ? (
                   <>
-                    <SPartName>디자인</SPartName> 파트 2명<SApplyingText> 신청중</SApplyingText>
+                    <SPartName>{partMembersData.part} 파트</SPartName> {partMembersData.participantCount ?? 0}명
+                    <SApplyingText> 신청중</SApplyingText>
                   </>
                 ) : (
                   <>
-                    38기 멤버 2명<SApplyingText> 신청 중</SApplyingText>
+                    {partMembersData?.participantCount ?? 0}명<SApplyingText> 신청 중</SApplyingText>
                   </>
                 )}
               </span>
@@ -340,7 +341,9 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
             isApplied={isApplied}
           />
         )}
-        {modalTitle.includes('신청 멤버') && <PartStatusModalContent appliedInfo={appliedInfo} />}
+        {modalTitle.includes('신청 멤버') && partMembersData && (
+          <PartStatusModalContent partMembersData={partMembersData} />
+        )}
       </DefaultModal>
     </>
   );

--- a/apps/crew/src/domain/detail/MeetingController/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/index.tsx
@@ -15,7 +15,6 @@ import { ERecruitmentStatus } from '@constant/option';
 import { CAPACITY } from '@domain/detail/MeetingController/constant';
 import FlashAbout from '@domain/detail/MeetingController/FlashAbout';
 import MeetingAbout from '@domain/detail/MeetingController/MeetingAbout';
-import { useDisplay } from '@hook/useDisplay';
 import useModal from '@hook/useModal';
 import DefaultModal from '@shared/modal/DefaultModal';
 import { playgroundLink } from '@sopt/constant';
@@ -34,6 +33,7 @@ import { ampli } from '@/ampli';
 
 import ProfileConfirmModal from './Modal/Confirm/ProfileConfirmModal';
 import ApplicationModalContent from './Modal/Content/ApplicationModalContent';
+import PartStatusModalContent from './Modal/Content/PartStatusModalContent';
 import RecruitmentStatusModalContent from './Modal/Content/RecruitmentStatusModalContent';
 
 interface DetailHeaderProps {
@@ -84,6 +84,15 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
     ampli.clickMemberStatus({ crew_status: approved || isHost });
     handleDefaultModalOpen();
     setModalTitle(`모집 현황 (${CAPACITY(detailData)})`);
+  };
+
+  // TODO: API 연결 후 실제 활동 여부 및 파트명/기수로 교체
+  const isActiveUser = true;
+
+  const handlePartStatusModal = () => {
+    const title = isActiveUser ? '디자인 파트 신청 멤버' : '38기 신청 멤버';
+    handleDefaultModalOpen();
+    setModalTitle(title);
   };
 
   const handleHostModalOpen = () => {
@@ -266,10 +275,18 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
         )}
         <div>
           <SStatusButtonWrapper>
-            <SPartStatusButton>
+            <SPartStatusButton onClick={handlePartStatusModal}>
               <span>
                 <SFireEmoji>🔥 </SFireEmoji>
-                <SPartName>디자인</SPartName> 파트 2명<SApplyingText> 신청중</SApplyingText>
+                {isActiveUser ? (
+                  <>
+                    <SPartName>디자인</SPartName> 파트 2명<SApplyingText> 신청중</SApplyingText>
+                  </>
+                ) : (
+                  <>
+                    38기 멤버 2명<SApplyingText> 신청 중</SApplyingText>
+                  </>
+                )}
               </span>
               <ArrowSmallRightIcon />
             </SPartStatusButton>
@@ -298,11 +315,13 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
           )}
         </div>
       </SPanelWrapper>
+
       <ProfileConfirmModal
         isModalOpened={isProfileModalOpened}
         handleModalClose={handleProfileModalClose}
         handleConfirm={() => (window.location.href = `${playgroundLink.memberUpload()}`)}
       />
+
       <DefaultModal
         isModalOpened={isDefaultModalOpened}
         title={modalTitle}
@@ -321,6 +340,7 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
             isApplied={isApplied}
           />
         )}
+        {modalTitle.includes('신청 멤버') && <PartStatusModalContent appliedInfo={appliedInfo} />}
       </DefaultModal>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11382,6 +11382,7 @@ __metadata:
     "@radix-ui/react-dropdown-menu": "npm:^2.1.1"
     "@sentry/nextjs": "npm:^7.0.0"
     "@sopt-makers/eslint-config": "workspace:^"
+    "@sopt-makers/fonts": "npm:^2.0.2"
     "@sopt-makers/icons": "npm:^1.1.0"
     "@sopt-makers/ui": "npm:^2.10.2"
     "@sopt/constant": "workspace:*"


### PR DESCRIPTION
## 📋 작업 내용

- [x] `GET /meeting/v2/{meetingId}/members` API 타입, 함수, 쿼리 추가
- [x] `PartStatusModalContent` 파트 멤버 API 응답 타입으로 교체 및 memberNames 기반 렌더링
- [x] `MeetingController`에서 `isActiveGeneration` 분기로 버튼 텍스트/모달 타이틀 처리
  - 활동 기수 (`isActiveGeneration: true`): `🔥 {파트} 파트 N명 신청 중` / `{파트} 파트 신청 멤버`
  - 명예 기수 (`isActiveGeneration: false`): `🔥 {기수}기 멤버 N명 신청 중` / `{기수}기 신청 멤버`
- [x] `MeetingAbout` subTitle 하드코딩 제거 후 API 응답으로 교체
- [x] schema2.d.ts 재생성 및 `generate-types-v2` URL 업데이트
- [x] `serialize.ts` 스키마 변경 대응 (`subTitle`, `joinInfo` 플레이스홀더, `welcomeMessageTypes` 제거)

## 📌 PR Point

- `isActiveGeneration` 필드로 현역/명예 기수를 구분해 각각 파트명 또는 기수 기준으로 분기 처리
- `memberProfileImages`, `memberIds` 필드가 스키마에 추가됐으나 현재 `PartStatusModalContent`에서는 이름만 표시 중 — 프로필 이미지 활용 여부는 추후 논의 필요
- `serialize.ts`의 `subTitle`, `joinInfo`는 다른 브랜치에서 폼 작업 완료 후 실제 값으로 교체 예정인 플레이스홀더

## 📸 스크린샷

<img width="1619" height="929" alt="image" src="https://github.com/user-attachments/assets/037b80b1-fce3-43ae-b0b5-b7bd67e55750" />
<img width="1709" height="924" alt="image" src="https://github.com/user-attachments/assets/40c820e5-de5c-462d-bd40-e17d2e885baf" />

---
🤖 made by [claude](https://claude.ai)
