### PR TITLE
fix: card 컴포넌트 subTitle 조건부 렌더링

### DIFF
--- a/apps/crew/src/domain/home/HomeCardList/DesktopCard.tsx
+++ b/apps/crew/src/domain/home/HomeCardList/DesktopCard.tsx
@@ -90,7 +90,7 @@ const SMetaSubStyle = styled('span', {
 });
 
 const STitleStyle = styled('h3', {
-  padding: '$4 0 $2',
+  pt: '$4',
 
   ...fontsObject.HEADING_6_18_B,
   display: '-webkit-box',
@@ -103,13 +103,14 @@ const STitleStyle = styled('h3', {
 const SSubTitle = styled('p', {
   ...fontsObject.BODY_2_16_M,
   color: '$gray200',
-  pb: '$8',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
+  pt: '$2',
 });
 
 const SMetaWrapper = styled('div', {
+  pt: '$8',
   display: 'flex',
   alignItems: 'center',
 });

--- a/apps/crew/src/domain/home/HomeCardList/DesktopCard.tsx
+++ b/apps/crew/src/domain/home/HomeCardList/DesktopCard.tsx
@@ -37,7 +37,7 @@ const DesktopCard = ({
         </SUserInfoWrapper>
 
         <STitleStyle>{title}</STitleStyle>
-        <SSubTitle>{subTitle}</SSubTitle>
+        {subTitle && <SSubTitle>{subTitle}</SSubTitle>}
 
         <SMetaWrapper>
           <SUserIcon />

--- a/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
+++ b/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
@@ -79,6 +79,7 @@ const SThumbnailImage = styled('img', {
 const SMetaWrapper = styled('div', {
   'display': 'flex',
   'flexDirection': 'column',
+  'justifyContent': 'center',
 
   'overflow': 'hidden',
   '@tablet': {

--- a/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
+++ b/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
@@ -113,7 +113,6 @@ const SSubTitle = styled('p', {
   'textOverflow': 'ellipsis',
   'whiteSpace': 'nowrap',
   'color': '$gray100',
-  'mb': '$8',
 
   '@tablet': {
     ...fontsObject.BODY_3_14_M,
@@ -127,7 +126,7 @@ const SInfoWrapper = styled('div', {
   display: 'flex',
   alignItems: 'center',
 
-  mb: '$8',
+  mt: '$8',
 });
 
 const SUserIcon = styled(UserIcon, {
@@ -172,6 +171,7 @@ const SDivider = styled('span', {
 });
 
 const SUserInfoWrapper = styled(Flex, {
+  'mt': '$8',
   '@tablet': { mb: '$2' },
   '@mobile': { mb: '$0' },
 });

--- a/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
+++ b/apps/crew/src/domain/home/HomeCardList/MobileCard.tsx
@@ -29,7 +29,7 @@ const MobileCard = ({
         <SThumbnailImage src={imageURL} />
         <SMetaWrapper>
           <STitle>{title}</STitle>
-          <SSubTitle>{subTitle}</SSubTitle>
+          {subTitle && <SSubTitle>{subTitle}</SSubTitle>}
 
           <SInfoWrapper>
             <SUserIcon />

--- a/apps/crew/src/shared/FloatingButton/index.tsx
+++ b/apps/crew/src/shared/FloatingButton/index.tsx
@@ -166,6 +166,7 @@ const ButtonWrapper = styled('button', {
   'position': 'fixed',
   'bottom': '5%',
   'right': '5%',
+  'zIndex': '$2',
 
   'display': 'flex',
   'flexDirection': 'column',


### PR DESCRIPTION
## 📋 작업 내용

- [x] card 컴포넌트 subTitle 조건부 렌더링
- [x] 간단 스타일 수정

## 📌 PR Point

이전 게시물들은 subTitle이 없어 조건부 렌더링 처리하고 스타일 조금 수정했어요!
그리고 기존에 플로팅버튼 모달이 z-index값이 적용 안되어있어서 추가했어요.

## 📸 스크린샷
<img width="242" height="243" alt="image" src="https://github.com/user-attachments/assets/83c87f0a-2552-4e5e-b45c-9446cb89e9a6" />
<img width="634" height="316" alt="image" src="https://github.com/user-attachments/assets/6b1bdf71-e918-4656-b673-d402acf93eec" />
<img width="699" height="352" alt="image" src="https://github.com/user-attachments/assets/d4af97c7-985c-420d-a560-167b7c4afac0" />
