### PR TITLE
fix: 멤버 상세 그룹 섹션 모바일 대응 및 스타일 수정

### DIFF
--- a/apps/playground/src/components/members/detail/GroupSection/index.tsx
+++ b/apps/playground/src/components/members/detail/GroupSection/index.tsx
@@ -5,7 +5,7 @@ import { fonts } from '@sopt-makers/fonts';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import axios from 'axios';
 import Link from 'next/link';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useMemberMeetingList } from '@/api/crew/getMeetingList';
 import type { ProfileDetail } from '@/api/endpoint_LEGACY/members/type';
@@ -26,9 +26,20 @@ const GroupSection = ({ profile, meId, memberId }: GroupSectionProps) => {
   const { data: meetingData, isPending, error: crewError } = useMemberMeetingList(memberId);
 
   const parentRef = useRef<HTMLDivElement>(null);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // @TODO: 추후에 상위 컴포넌트에서 주입
+  useEffect(() => {
+    const media = window.matchMedia(MOBILE_MEDIA_QUERY);
+    setIsMobile(media.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, []);
 
   const meetingList = meetingData?.userAppliedMeetings ?? []; // 데이터를 안전하게 추출
-  const ITEMS_PER_ROW = 2;
+  const ITEMS_PER_ROW = isMobile ? 1 : 2;
   const ROW_COUNT = Math.ceil(meetingList.length / ITEMS_PER_ROW);
 
   const rowVirtualizer = useVirtualizer({
@@ -59,7 +70,7 @@ const GroupSection = ({ profile, meId, memberId }: GroupSectionProps) => {
           <ActivityDisplay
             ref={parentRef}
             style={{
-              height: '800px',
+              maxHeight: '800px',
               overflowY: 'auto',
             }}
           >
@@ -169,12 +180,13 @@ const ActivityUploadNudge = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin-top: 60px;
+  margin-top: 20px;
   border-radius: 30px;
   background-color: ${colors.gray800};
   height: 317px;
 
   @media ${MOBILE_MEDIA_QUERY} {
+    margin-top: 16px;
     padding: 20px;
     height: 212px;
   }


### PR DESCRIPTION
## 📋 작업 내용

- [x] `GroupSection` 컴포넌트에 모바일 미디어 쿼리 대응 추가
  - 모바일에서는 한 행에 1개, 그 외 환경에서는 2개씩 카드를 노출하도록 `ITEMS_PER_ROW` 동적 분기
  - `matchMedia`를 활용한 미디어 쿼리 변화 감지 및 리스너 정리
- [x] 가상화 영역(`ActivityDisplay`)의 고정 `height: 800px`를 `maxHeight: 800px`로 변경하여 콘텐츠 양에 따라 높이가 유연하게 줄어들도록 수정
- [x] `ActivityUploadNudge`의 상단 여백 조정 (데스크탑 60px → 20px, 모바일 16px 추가)

## 📌 PR Point

- 가상화 리스트의 `ITEMS_PER_ROW`를 미디어 쿼리에 따라 동적으로 결정해야 해서, 클라이언트에서 `matchMedia`를 구독하는 형태로 구현했습니다.
- 미디어 쿼리 감지 로직은 추후 상위 컴포넌트에서 주입받는 형태로 리팩터링이 필요해 `@TODO` 주석을 남겨두었습니다.
- `height` → `maxHeight` 변경으로 활동 내역이 적을 때 빈 공간이 생기지 않도록 처리했는데, 가상화 동작에 영향이 없는지 확인 부탁드립니다.

## 📸 스크린샷

| As-is | To-be |
|---|---|
| <img width="344" height="463" alt="as-is" src="https://github.com/user-attachments/assets/e8442885-9be7-4ae3-bfe8-57c7c9573c39" /> | <img width="312" height="450" alt="to-be" src="https://github.com/user-attachments/assets/49c19a4c-d492-4b34-bf7c-e0e0c9f334af" /> |
---
🤖 made by [claude](https://claude.ai)
