### PR TITLE
fix: 검색 입력값 처리 개선 및 불필요한 키 삭제 로직 수정

### DIFF
--- a/apps/crew/src/domain/list/Filter/Search/Mobile.tsx
+++ b/apps/crew/src/domain/list/Filter/Search/Mobile.tsx
@@ -12,8 +12,14 @@ function SearchMobile() {
   const { bool: isVisible, toggle } = useBooleanState();
 
   const onSubmit = (value: FieldValues) => {
-    if (!value?.search) deleteKey();
-    if (value.search) setSearch(value.search);
+    const searchValue = typeof value.search === 'string' ? value.search.trim() : '';
+
+    if (!searchValue) {
+      deleteKey();
+      return;
+    }
+
+    setSearch(searchValue);
   };
 
   const handleCancel = () => {

--- a/apps/crew/src/domain/list/Filter/Search/index.tsx
+++ b/apps/crew/src/domain/list/Filter/Search/index.tsx
@@ -2,7 +2,7 @@ import { useSearchParams } from '@hook/queryString/custom';
 import { SearchField } from '@sopt-makers/ui';
 import { css } from '@stitches/react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import SearchMobile from './Mobile';
 
@@ -33,9 +33,9 @@ function Search() {
   const searchQuery = String(router.query.search || '');
   const [inputValue, setInputValue] = useState(searchQuery);
 
-  if (!inputValue && searchQuery !== inputValue) {
-    deleteKey();
-  }
+  useEffect(() => {
+    setInputValue(searchQuery);
+  }, [searchQuery]);
 
   return (
     <SearchField
@@ -46,8 +46,14 @@ function Search() {
         setInputValue(e.target.value);
       }}
       onSubmit={() => {
-        setSearch(inputValue);
-        setInputValue(inputValue);
+        const searchValue = inputValue.trim();
+
+        if (!searchValue) {
+          deleteKey();
+          return;
+        }
+
+        setSearch(searchValue);
       }}
       onReset={() => {
         setInputValue('');


### PR DESCRIPTION
## 📋 작업 내용

- [x] 전체 모입 탭에서 배너 더보기 링크 진입 시 진입 안되는 이슈 해결

## 📌 PR Point

전체 모임 페이지에서 배너 링크로 search query가 포함된 URL에 진입하면 검색 input의 초기 상태와 URL query가 어긋나 렌더 중 search query가 삭제되는 문제가 있었어요.
따라서 URL의 search query를 input 상태에 동기화하도록 수정하고 desktop/mobile 모두 검색어 앞뒤 공백은 제거하되 공백만 입력한 경우에는 검색어를 삭제하도록 처리했습니다.
