### PR TITLE
fix: SP1 QA - TableOfContents 신규 필드 유효성 검사 분기 처리 및 안내 문구 수정

### DIFF
--- a/apps/crew/pages/edit/index.tsx
+++ b/apps/crew/pages/edit/index.tsx
@@ -130,6 +130,7 @@ const EditPage = () => {
           cancelButtonLabel='수정 취소하기'
           submitButtonLabel='정보 수정하기'
           disabled={isSubmitting || !isValid || Object.keys(errors).length > 0 || !isDirty}
+          showLegacyFields={showLegacyFields}
         />
       </SContainer>
       {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
@@ -20,7 +20,7 @@ const PartStatusModalContent = ({ partMembersData }: PartStatusModalContentProps
           </SList>
         </SListWrapper>
       ) : (
-        <SEmptyText>신청자가 없습니다.</SEmptyText>
+        <SEmptyText>신청자가 아직 없어요.</SEmptyText>
       )}
       {memberNames.length > 0 && (
         <SModalBottom>

--- a/apps/crew/src/shared/form/Presentation/ParticipationInfoField/index.tsx
+++ b/apps/crew/src/shared/form/Presentation/ParticipationInfoField/index.tsx
@@ -11,7 +11,7 @@ const ParticipationInfoField = () => {
   return (
     <div>
       <Label required>참여 정보</Label>
-      <HelpMessage>모임 참여 방식과 강도를 선택해주세요.각 1가지</HelpMessage>
+      <HelpMessage>모임 참여 방식과 강도를 선택해주세요. 항목 별로 1개씩 선택할 수 있어요.</HelpMessage>
       <SFieldWrapper>
         <div>
           <SSubLabel>참여 방식</SSubLabel>

--- a/apps/crew/src/shared/form/Presentation/SubtitleField/index.tsx
+++ b/apps/crew/src/shared/form/Presentation/SubtitleField/index.tsx
@@ -8,7 +8,7 @@ const SubtitleField = () => {
   return (
     <SSubtitleField>
       <Label required>모임 한줄 소개</Label>
-      <HelpMessage>모임을 한마디로 소개해주세요. 개설 후 제목 아래 부제목으로 노출돼요.</HelpMessage>
+      <HelpMessage>모임을 한마디로 소개해주세요. 모임 이름 아래 한 줄로 보여지는 내용이에요.</HelpMessage>
       <FormController
         name='subTitle'
         render={({ field, fieldState: { error } }) => (

--- a/apps/crew/src/shared/form/Presentation/TargetField/index.tsx
+++ b/apps/crew/src/shared/form/Presentation/TargetField/index.tsx
@@ -15,7 +15,7 @@ const TargetField = () => {
           </Label>
         </SLabelWrapper>
       </SLabelCheckboxWrapper>
-      <HelpMessage>모임장을 제외한 인원 수를 입력해주세요</HelpMessage>
+      <HelpMessage>대상을 선택하고 모임장을 제외한 인원 수를 입력해주세요.</HelpMessage>
       <FormController
         name='detail.targetDesc'
         render={() => {

--- a/apps/crew/src/shared/form/TableOfContents/index.tsx
+++ b/apps/crew/src/shared/form/TableOfContents/index.tsx
@@ -16,9 +16,17 @@ interface TableOfContentsProps {
   cancelButtonLabel?: React.ReactNode;
   submitButtonLabel: React.ReactNode;
   disabled: boolean;
+  showLegacyFields?: boolean;
 }
 
-function TableOfContents({ label, onSubmit, cancelButtonLabel, submitButtonLabel, disabled }: TableOfContentsProps) {
+function TableOfContents({
+  label,
+  onSubmit,
+  cancelButtonLabel,
+  submitButtonLabel,
+  disabled,
+  showLegacyFields = false,
+}: TableOfContentsProps) {
   const router = useRouter();
   const isEdit = router.asPath.includes('/edit');
 
@@ -58,6 +66,11 @@ function TableOfContents({ label, onSubmit, cancelButtonLabel, submitButtonLabel
   const hasWelcomeMessageTypes =
     form.welcomeMessageTypes && form.welcomeMessageTypes.length > 0 && !errors.welcomeMessageTypes;
 
+  const isSubtitleValid = !showLegacyFields && form.subTitle && !errors.subTitle;
+  const isParticipationMethodValid = !showLegacyFields && form.participationMethod && !errors.participationMethod;
+  const isParticipationIntensityValid =
+    !showLegacyFields && form.participationIntensity && !errors.participationIntensity;
+
   const isRequiredInfoChecked =
     isTitleValid &&
     isCategoryValid &&
@@ -65,7 +78,8 @@ function TableOfContents({ label, onSubmit, cancelButtonLabel, submitButtonLabel
     isImageValid &&
     isDescriptionValid &&
     isApplicationDateValid &&
-    isTargetValid;
+    isTargetValid &&
+    (showLegacyFields || (isSubtitleValid && isParticipationMethodValid && isParticipationIntensityValid));
 
   const isOptionalInfoChecked = hasCoLeader || hasLeaderDesc || hasWelcomeMessageTypes;
 


### PR DESCRIPTION
## 📋 작업 내용

- [x] `TableOfContents`에 `showLegacyFields` prop 추가 및 신규 필드(`subTitle`, `participationMethod`, `participationIntensity`) 유효성 검사 분기 처리
- [x] 수정 페이지(`edit/index.tsx`)에서 `TableOfContents`로 `showLegacyFields` 전달
- [x] 폼 필드 안내 문구 수정 (`SubtitleField`, `ParticipationInfoField`, `TargetField`)
- [x] 신청자 없음 모달 문구 수정 (`PartStatusModalContent`)

## 📌 PR Point

- `subTitle`, `participationMethod`, `participationIntensity` 세 필드는 구 모임(`showLegacyFields=true`)에는 존재하지 않으므로, `TableOfContents`의 `isRequiredInfoChecked` 계산 시 레거시 여부에 따라 분기 처리함
- 생성 페이지(`make`)는 `showLegacyFields` 기본값 `false`로 항상 세 필드를 체크하고, 수정 페이지(`edit`)는 컷오프 날짜 기준으로 결정된 `showLegacyFields` 값을 그대로 내려줌
- `isRequiredInfoChecked` 조건: `showLegacyFields`가 `true`면 세 필드 검사를 건너뜀, `false`면 세 필드 모두 유효해야 통과

---
🤖 made by [claude](https://claude.ai)
