### PR TITLE
fix: 내 모임탭 반응형 수정

### DIFF
--- a/apps/crew/src/domain/list/Card/index.tsx
+++ b/apps/crew/src/domain/list/Card/index.tsx
@@ -22,7 +22,7 @@ function Card({ bottom, meetingData, mobileType }: CardProps) {
   return (
     <CardWrapper
       css={{
-        '@mobile': { width: mobileType === 'list' ? '100%' : 'fit-content' },
+        '@new_mobile': { width: mobileType === 'list' ? '100%' : 'fit-content' },
       }}
       onClick={() => {
         ampli.clickGroupCard({
@@ -53,18 +53,18 @@ export default Card;
 
 const CardWrapper = styled('li', {
   'minWidth': 0,
-  '@mobile': {
+  '@new_mobile': {
     justifySelf: 'stretch',
   },
 });
 const DesktopOnly = styled('div', {
-  '@mobile': {
+  '@new_mobile': {
     display: 'none',
   },
 });
 const MobileOnly = styled('div', {
   'display': 'none',
-  '@mobile': {
+  '@new_mobile': {
     display: 'flex',
     width: '100%',
   },


### PR DESCRIPTION
## 📋 작업 내용

- [x] 반응형 깨짐 문제 해결

## 📌 PR Point

내 `모임 홈`, `전체 모임` 탭 카드컴포넌트 구현하면서 사이즈가 변경돼서 이 카드를 쓰는 `내 모임`탭의 grid가 깨지는 현상 고쳤어요.

## 📸 스크린샷
