### PR TITLE
feat: 에스크 미리보기 클릭 시 에스크 탭으로 이동 로직 추가

### DIFF
--- a/apps/playground/src/api/endpoint/members/getQuestionLocation.ts
+++ b/apps/playground/src/api/endpoint/members/getQuestionLocation.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import { createEndpoint } from '@/api/typedAxios';
+
+const getQuestionLocationResponseScheme = z.object({
+  questionId: z.number(),
+  tab: z.enum(['answered', 'unanswered']),
+  page: z.number(),
+  index: z.number(),
+});
+
+export type GetQuestionLocationResponse = z.infer<typeof getQuestionLocationResponseScheme>;
+
+interface GetQuestionLocationRequest {
+  memberId: number;
+  questionId: number;
+}
+
+export const getQuestionLocationEndpoint = createEndpoint({
+  request: ({ memberId, questionId }: GetQuestionLocationRequest) => ({
+    method: 'GET',
+    url: `/api/v1/members/${memberId}/questions/${questionId}/location`,
+  }),
+  serverResponseScheme: getQuestionLocationResponseScheme,
+});

--- a/apps/playground/src/components/members/detail/ActivitySection/AskTabContent.tsx
+++ b/apps/playground/src/components/members/detail/ActivitySection/AskTabContent.tsx
@@ -136,7 +136,7 @@ const AskTabContent = ({ memberId, memberName, meId, unansweredCount }: AskTabCo
   };
 
   useEffect(() => {
-    if (selectedTab !== 'answered' || scrollTargetIndex == null || questions.length === 0) return;
+    if (scrollTargetIndex == null || questions.length === 0) return;
 
     if (isLoading) return;
 

--- a/apps/playground/src/components/members/main/MemberCard/index.tsx
+++ b/apps/playground/src/components/members/main/MemberCard/index.tsx
@@ -3,9 +3,11 @@ import { playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { Tag } from '@sopt-makers/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { m } from 'framer-motion';
 import { useRouter } from 'next/router';
 
+import { getQuestionLocationEndpoint } from '@/api/endpoint/members/getQuestionLocation';
 import type { QuestionPreview } from '@/api/endpoint_LEGACY/members/type';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
@@ -60,12 +62,28 @@ const MemberCard = ({
     router.push(playgroundLink.coffeechatDetail(memberId));
   };
 
+  const queryClient = useQueryClient();
   const { logClickEvent } = useEventLogger();
-  const handleAskPreviewClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleAskPreviewClick = async (e: React.MouseEvent<HTMLDivElement>, questionPreview: QuestionPreview) => {
     e.stopPropagation();
     e.preventDefault();
-    // TODO: 에스크탭으로 페이지네이션 로직 추가
     logClickEvent('memberAskPreview', { id: memberId, name: name });
+
+    const params = { memberId, questionId: questionPreview.questionId };
+    const questionLocation = await queryClient.fetchQuery({
+      queryKey: getQuestionLocationEndpoint.cacheKey(params),
+      queryFn: () => getQuestionLocationEndpoint.request(params),
+    });
+
+    router.push({
+      pathname: `/members/${memberId}`,
+      query: {
+        tab: 'ask',
+        questionTab: questionLocation.tab,
+        scrollPage: questionLocation.page + 1,
+        scrollIndex: questionLocation.index,
+      },
+    });
   };
 
   return (
@@ -139,7 +157,7 @@ const MemberCard = ({
         )}
 
         {questionPreview && (
-          <StyledAskPreviewBubble onClick={handleAskPreviewClick}>
+          <StyledAskPreviewBubble onClick={(e) => handleAskPreviewClick(e, questionPreview)}>
             <Tag size='sm' shape='rect' variant='primary' type='solid'>
               ASK
             </Tag>


### PR DESCRIPTION
## 📋 작업 내용

- [x] 에스크 위치 조회 api 연결
- [x] 새 질문 탭에도 스크롤 로직 추가

## 📌 PR Point

### `fetchQuery` 사용한 이유
처음엔 `useQuery`로 처리하려 했는데, 그러면 `MemberCard` 마운트 시점에 요청이 나가서 사용자가 클릭하지 않아도 api가 호출되는 문제가 있었어요.
에스크 미리보기를 클릭한 시점에만 요청이 가는 게 맞다고 판단해서 `useQuery`에서 `fetchQuery`로 바꿨어요.

<hr />

### 새 질문 탭에 스크롤 로직 추가
<img width="156" height="55" alt="image" src="https://github.com/user-attachments/assets/eaca2727-ec6c-4c55-8e25-0625a4584f6e" />

에스크 미리보기는 답변 완료, 새 질문(답변 미완료)에 상관없이 에스크를 띄우고 있어요.
그런데 스크롤 로직은 답변 완료 탭에만 적용이 되어 있어서 새 질문 탭에도 적용하기 위해 `if (selectedTab !== 'answered') return` 분기를 삭제했어요.


## 📸 스크린샷

https://github.com/user-attachments/assets/a6533aea-44b9-41a6-85db-13ca8aecd6d9

