### PR TITLE
fix: PartStatusModalContent API 업데이트 및 UI 정상화

### DIFF
--- a/apps/crew/src/__generated__/schema2.d.ts
+++ b/apps/crew/src/__generated__/schema2.d.ts
@@ -2040,6 +2040,51 @@ export interface components {
       /** @description 모임 키워드 타입 목록 */
       meetingKeywordTypes: string[];
     };
+    /** @description 모임 같은 파트/기수 신청 정보 조회 dto */
+    ApplyMemberInfoDto: {
+      /**
+       * Format: int32
+       * @description 신청 id
+       * @example 3
+       */
+      id: number;
+      /**
+       * Format: int32
+       * @description 신청 번호
+       * @example 1
+       */
+      applyNumber: number;
+      /**
+       * Format: int32
+       * @description 신청 타입
+       * @example 0
+       */
+      type: number;
+      /**
+       * Format: int32
+       * @description 모임 id
+       * @example 13
+       */
+      meetingId: number;
+      /**
+       * Format: int32
+       * @description 신청자 id
+       * @example 184
+       */
+      userId: number;
+      /**
+       * Format: date-time
+       * @description 신청 날짜 및 시간
+       */
+      appliedDate: string;
+      /**
+       * Format: int32
+       * @description 신청 상태
+       * @example 1
+       */
+      status: number;
+      user: components['schemas']['ApplicantByMeetingDto'];
+    };
     /** @description 모임 내 같은 파트/기수 참여 멤버 리스트 조회 dto */
     MeetingV2GetMeetingPartMembersResponseDto: {
       /**
@@ -2064,30 +2109,8 @@ export interface components {
        * @example 38
        */
       activeGeneration?: number;
-      /**
-       * @description 유저 리스트의 index id
-       * @example [
-       *   1,
-       *   2
-       * ]
-       */
-      memberIds?: number[];
-      /**
-       * @description 유저 이름 리스트
-       * @example [
-       *   "이지훈",
-       *   "김효준"
-       * ]
-       */
-      memberNames?: string[];
-      /**
-       * @description 유저 프로필 이미지 리스트
-       * @example [
-       *   "https://example.com/profile.png",
-       *   null
-       * ]
-       */
-      memberProfileImages?: string[];
+      /** @description 조건에 맞는 신청 정보 목록 */
+      appliedInfo?: components['schemas']['ApplyMemberInfoDto'][];
     };
     /** @description 모임 신청자 객체 Dto */
     ApplicantDto: {

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
@@ -1,4 +1,8 @@
 import type { GetMeetingPartMembers } from '@api/meeting/type';
+import { useUserProfileQueryOption } from '@api/user/query';
+import ProfileDefaultIcon from '@assets/svg/profile_default.svg?rect';
+import { APPROVAL_STATUS, EApprovalStatus } from '@constant/option';
+import { useQuery } from '@tanstack/react-query';
 import { styled } from 'stitches.config';
 
 interface PartStatusModalContentProps {
@@ -6,23 +10,33 @@ interface PartStatusModalContentProps {
 }
 
 const PartStatusModalContent = ({ partMembersData }: PartStatusModalContentProps) => {
-  const memberNames = partMembersData.memberNames ?? [];
-  const total = partMembersData.participantCount ?? memberNames.length;
+  const { data: me } = useQuery(useUserProfileQueryOption());
+  const appliedInfo = partMembersData.appliedInfo ?? [];
+  const total = partMembersData.participantCount ?? appliedInfo.length;
 
   return (
     <>
-      {memberNames.length > 0 ? (
+      {appliedInfo.length > 0 ? (
         <SListWrapper>
-          <SList>
-            {memberNames.map((name, idx) => (
-              <SItem key={idx}>{name}</SItem>
-            ))}
-          </SList>
+          <SScrollWrapper>
+            <SList>
+              {appliedInfo.map(({ status, applyNumber, user: { orgId, id, name, profileImage } }) => (
+                <SItem key={id} isActive={me?.orgId === orgId}>
+                  <div>
+                    <AppliedNumberText>{applyNumber}</AppliedNumberText>
+                    {profileImage ? <img src={profileImage} alt='' /> : <ProfileDefaultIcon />}
+                    <span>{name}</span>
+                  </div>
+                  <SStatusText isApproved={status === EApprovalStatus.APPROVE}>{APPROVAL_STATUS[status]}</SStatusText>
+                </SItem>
+              ))}
+            </SList>
+          </SScrollWrapper>
         </SListWrapper>
       ) : (
         <SEmptyText>신청자가 아직 없어요.</SEmptyText>
       )}
-      {memberNames.length > 0 && (
+      {appliedInfo.length > 0 && (
         <SModalBottom>
           <STotal>총 {total}명 신청</STotal>
         </SModalBottom>
@@ -41,22 +55,12 @@ const SListWrapper = styled('div', {
   },
 });
 
-const SList = styled('div', {
-  'display': 'grid',
-  'gridTemplateColumns': 'repeat(2, 1fr)',
-  'gap': '$12',
-  'padding': '0 $24',
+const SScrollWrapper = styled('div', {
   'height': '$219',
   'overflowY': 'scroll',
 
   '@tablet': {
-    gap: '$8',
-    padding: '0 $20',
     height: '$160',
-  },
-
-  '@mobile': {
-    gridTemplateColumns: '1fr',
   },
 
   '&::-webkit-scrollbar': {
@@ -70,19 +74,121 @@ const SList = styled('div', {
   },
 });
 
+const SList = styled('div', {
+  'display': 'grid',
+  'gridTemplateColumns': 'repeat(2, 1fr)',
+  'gap': '$12',
+  'padding': '0 $24',
+
+  '@tablet': {
+    gap: '$8',
+    padding: '0 $20',
+  },
+
+  '@mobile': {
+    gridTemplateColumns: '1fr',
+  },
+});
+
 const SItem = styled('div', {
   'flexType': 'verticalCenter',
+  'justifyContent': 'space-between',
+
+  'width': '100%',
   'height': '$64',
   'padding': '$16 $20',
+
   'borderRadius': '12px',
   'backgroundColor': '$gray700',
   'color': '$gray10',
+
   'fontAg': '16_semibold_100',
 
   '@tablet': {
     height: '$48',
     padding: '$11 $12',
     fontAg: '14_medium_100',
+  },
+
+  'div': {
+    flexType: 'verticalCenter',
+  },
+
+  'img': {
+    'width': '$32',
+    'height': '$32',
+    'borderRadius': '$round',
+    'objectFit': 'cover',
+    'background': '$gray600',
+
+    '@tablet': {
+      width: '$26',
+      height: '$26',
+    },
+  },
+
+  'svg': {
+    'width': '$32',
+    'height': '$32',
+
+    '@tablet': {
+      width: '$26',
+      height: '$26',
+    },
+  },
+
+  'span': {
+    'ml': '$10',
+    'whiteSpace': 'nowrap',
+    'overflow': 'hidden',
+    'textOverflow': 'ellipsis',
+    'maxWidth': '$154',
+
+    '@tablet': {
+      maxWidth: '$61',
+    },
+  },
+
+  'variants': {
+    isActive: {
+      true: {
+        border: '1px solid $gray10',
+      },
+      false: {
+        border: 'none',
+      },
+    },
+  },
+});
+
+const AppliedNumberText = styled('p', {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+
+  width: '$30',
+  mr: '$10',
+});
+
+const SStatusText = styled('div', {
+  'ml': '$14',
+  'color': '$gray500',
+  'fontAg': '14_medium_100',
+
+  'variants': {
+    isApproved: {
+      true: {
+        color: '$success',
+      },
+      false: {
+        color: '$gray500',
+      },
+    },
+  },
+
+  '@tablet': {
+    ml: '$9',
+    fontSize: '$10',
   },
 });
 

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/RecruitmentStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/RecruitmentStatusModalContent/index.tsx
@@ -32,7 +32,7 @@ const RecruitmentStatusModalContent = ({
           <RecruitmentStatusList recruitmentStatusList={appliedInfo} />
         </SRecruitmentStatusListWrapper>
       ) : (
-        <SEmptyText>{isHost ? '신청자' : '참여자'}가 없습니다.</SEmptyText>
+        <SEmptyText>{isHost ? '신청자' : '참여자'}가 아직 없어요.</SEmptyText>
       )}
       {isBottomVisible && (
         <SRecruitmentStatusModalBottom>


### PR DESCRIPTION
## 📋 작업 내용

- [x] `PartStatusModalContent` API 응답 형식 업데이트 (`memberNames[]` → `appliedInfo[]`)
- [x] `PartStatusModalContent` UI를 `RecruitmentStatusModalContent`와 동일한 카드 형태로 정상화
  - 프로필 이미지, 신청 번호, 이름, 승인 상태 표시
  - 본인 항목 강조 테두리 (`orgId` 비교)
  - 스크롤 wrapper와 grid 분리로 아이템 간격 정상화
- [x] `schema2.d.ts` 내 `MeetingV2GetMeetingPartMembersResponseDto` 타입 업데이트
  - `memberIds`, `memberNames`, `memberProfileImages` 필드 제거
  - `appliedInfo: ApplyMemberInfoDto[]` 필드 추가
- [x] `RecruitmentStatusModalContent` 빈 상태 문구 통일 (`~가 없습니다.` → `~가 아직 없어요.`)

## 📌 PR Point

- `PartStatusModalContent`의 `appliedInfo` 타입(`ApplyMemberInfoDto`)은 `RecruitmentStatusList`가 사용하는 `ApplyWholeInfoDto`와 `content` 필드 유무만 다르고 렌더링에 필요한 필드(`status`, `applyNumber`, `user.orgId`, `user.id`, `user.name`, `user.profileImage`)는 동일함 → 타입 캐스팅 없이 별도 인라인 구현으로 처리
- 기존 구현에서 grid 컨테이너에 직접 `height: $219`를 줘서 row가 공간을 채우려 늘어나던 문제 수정 → 스크롤 wrapper와 grid를 분리
- `PartStatusModalContent`는 관리 링크(`신청자 관리`) 없이 총원만 표시 — `RecruitmentStatusModalContent`와 UI 형태만 동일, 내부 텍스트는 독립적으로 유지

## 📸 스크린샷

<img width="1701" height="873" alt="image" src="https://github.com/user-attachments/assets/ea476494-b031-46f9-b0fa-8dab44bc0645" />
---
🤖 made by [claude](https://claude.ai)
