### PR TITLE
fix: old 모임 수정 API 오류 및 flash 상세 페이지 버그 수정

### DIFF
--- a/apps/crew/package.json
+++ b/apps/crew/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@emotion/server": "^11.9.0",
-    "@hookform/devtools": "^4.3.1",
+    "@hookform/devtools": "4.3.1",
     "@sopt-makers/eslint-config": "workspace:^",
     "@types/react-mentions": "4.1.13",
     "@types/react-responsive": "^8.0.5",

--- a/apps/crew/pages/edit/index.tsx
+++ b/apps/crew/pages/edit/index.tsx
@@ -10,7 +10,7 @@ import { colors } from '@sopt-makers/colors';
 import { fontsObject } from '@sopt-makers/fonts';
 import { useQuery } from '@tanstack/react-query';
 import type { FormType } from '@type/form';
-import { createSchema, schema } from '@type/form';
+import { legacyMeetingEditSchema, newMeetingEditSchema } from '@type/form';
 import { formatCalendarDate } from '@util/dayjs';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
@@ -34,7 +34,7 @@ const EditPage = () => {
 
   const formMethods = useForm<FormType>({
     mode: 'onChange',
-    resolver: zodResolver(showLegacyFields ? schema : createSchema),
+    resolver: zodResolver(showLegacyFields ? legacyMeetingEditSchema : newMeetingEditSchema),
     defaultValues: {
       detail: {
         coLeader: [],

--- a/apps/crew/src/__generated__/schema2.d.ts
+++ b/apps/crew/src/__generated__/schema2.d.ts
@@ -1083,6 +1083,14 @@ export interface components {
        * ]
        */
       welcomeMessageTypes?: string[];
+      /**
+       * @description 모임 키워드 타입 리스트
+       * @example [
+       *   "운동",
+       *   "먹방"
+       * ]
+       */
+      meetingKeywordTypes?: string[];
     };
     /** @description 전체 사용자 조회 응답 Dto */
     UserV2GetAllUserDto: {
@@ -2040,6 +2048,51 @@ export interface components {
       /** @description 모임 키워드 타입 목록 */
       meetingKeywordTypes: string[];
     };
+    /** @description 모임 같은 파트/기수 신청 정보 조회 dto */
+    ApplyMemberInfoDto: {
+      /**
+       * Format: int32
+       * @description 신청 id
+       * @example 3
+       */
+      id: number;
+      /**
+       * Format: int32
+       * @description 신청 번호
+       * @example 1
+       */
+      applyNumber: number;
+      /**
+       * Format: int32
+       * @description 신청 타입
+       * @example 0
+       */
+      type: number;
+      /**
+       * Format: int32
+       * @description 모임 id
+       * @example 13
+       */
+      meetingId: number;
+      /**
+       * Format: int32
+       * @description 신청자 id
+       * @example 184
+       */
+      userId: number;
+      /**
+       * Format: date-time
+       * @description 신청 날짜 및 시간
+       */
+      appliedDate: string;
+      /**
+       * Format: int32
+       * @description 신청 상태
+       * @example 1
+       */
+      status: number;
+      user: components['schemas']['ApplicantByMeetingDto'];
+    };
     /** @description 모임 내 같은 파트/기수 참여 멤버 리스트 조회 dto */
     MeetingV2GetMeetingPartMembersResponseDto: {
       /**
@@ -2064,30 +2117,8 @@ export interface components {
        * @example 38
        */
       activeGeneration?: number;
-      /**
-       * @description 유저 리스트의 index id
-       * @example [
-       *   1,
-       *   2
-       * ]
-       */
-      memberIds?: number[];
-      /**
-       * @description 유저 이름 리스트
-       * @example [
-       *   "이지훈",
-       *   "김효준"
-       * ]
-       */
-      memberNames?: string[];
-      /**
-       * @description 유저 프로필 이미지 리스트
-       * @example [
-       *   "https://example.com/profile.png",
-       *   null
-       * ]
-       */
-      memberProfileImages?: string[];
+      /** @description 조건에 맞는 신청 정보 목록 */
+      appliedInfo?: components['schemas']['ApplyMemberInfoDto'][];
     };
     /** @description 모임 신청자 객체 Dto */
     ApplicantDto: {

--- a/apps/crew/src/api/flash/query.ts
+++ b/apps/crew/src/api/flash/query.ts
@@ -6,6 +6,7 @@ export const useFlashQueryOption = ({ meetingId }: { meetingId: number }) => {
   return queryOptions({
     queryKey: FlashQueryKey.detail(meetingId),
     queryFn: () => getFlash(meetingId),
+    enabled: !!meetingId,
   });
 };
 

--- a/apps/crew/src/api/meeting/index.ts
+++ b/apps/crew/src/api/meeting/index.ts
@@ -5,6 +5,7 @@ import type {
   GetMeetingMemberList,
   GetMeetingPartMembers,
   GetRecommendMeetingList,
+  PatchMeeting,
   PostMeeting,
   PostMeetingApplication,
   UpdateMeetingApplication,
@@ -24,11 +25,8 @@ export const getMeeting = async ({ meetingId }: GetMeeting['request']): Promise<
   return (await api.get<GetMeeting['response']>(`/meeting/v2/${meetingId}`)).data;
 };
 
-export const patchMeeting = async (
-  meetingId: number,
-  body: PostMeeting['request'],
-): Promise<PostMeeting['response']> => {
-  return (await api.patch<PostMeeting['response']>(`/meeting/v2/${meetingId}`, body)).data;
+export const patchMeeting = async (meetingId: number, body: PatchMeeting['request']): Promise<void> => {
+  await api.patch(`/meeting/v2/${meetingId}`, body);
 };
 
 export const deleteMeeting = async (id: number) => {

--- a/apps/crew/src/api/meeting/mutation.ts
+++ b/apps/crew/src/api/meeting/mutation.ts
@@ -14,7 +14,7 @@ import {
   postMeetingApplication,
   updateMeetingApplication,
 } from '.';
-import { serializeMeetingData } from './serialize';
+import { serializeMeetingData, serializeUpdateMeetingData } from './serialize';
 
 export const useDeleteMeetingMutation = () => {
   return useMutation({
@@ -41,7 +41,7 @@ export const usePatchMeetingMutation = (meetingId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (formData: FormType) => patchMeeting(meetingId, serializeMeetingData(formData)),
+    mutationFn: (formData: FormType) => patchMeeting(meetingId, serializeUpdateMeetingData(formData)),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: MeetingQueryKey.detail(meetingId),

--- a/apps/crew/src/api/meeting/serialize.ts
+++ b/apps/crew/src/api/meeting/serialize.ts
@@ -12,8 +12,8 @@ export const serializeMeetingData = (formData: FormType): PostMeeting['request']
     title: formData.title,
     subTitle: formData.subTitle ?? '',
     joinInfo: {
-      meetingType: formData.participationMethod,
-      meetingFrequency: formData.participationIntensity,
+      meetingType: formData.participationMethod ?? undefined,
+      meetingFrequency: formData.participationIntensity ?? undefined,
     },
     files: formData.files,
     category: formData.category.value,

--- a/apps/crew/src/api/meeting/serialize.ts
+++ b/apps/crew/src/api/meeting/serialize.ts
@@ -1,6 +1,6 @@
 import type { FormType } from '@type/form';
 
-import type { PostMeeting } from './type';
+import type { PatchMeeting, PostMeeting } from './type';
 
 export const serializeMeetingData = (formData: FormType): PostMeeting['request'] => {
   const refinedParts = formData.detail.joinableParts
@@ -15,6 +15,40 @@ export const serializeMeetingData = (formData: FormType): PostMeeting['request']
       meetingType: formData.participationMethod ?? undefined,
       meetingFrequency: formData.participationIntensity ?? undefined,
     },
+    files: formData.files,
+    category: formData.category.value,
+    startDate: formData.dateRange[0] ?? '',
+    endDate: formData.dateRange[1] ?? '',
+    capacity: formData.capacity,
+    desc: formData.detail.desc,
+    processDesc: '',
+    mStartDate: '',
+    mEndDate: '',
+    leaderDesc: formData.detail.leaderDesc ?? '',
+    note: '',
+    isMentorNeeded: formData.detail.isMentorNeeded ?? false,
+    canJoinOnlyActiveGeneration: formData.detail.canJoinOnlyActiveGeneration ?? false,
+    joinableParts: refinedParts,
+    coLeaderUserIds: formData.detail.coLeader?.map((user) => user.userId) ?? [],
+    meetingKeywordTypes: formData.meetingKeywordTypes === null ? undefined : formData.meetingKeywordTypes,
+  };
+};
+
+export const serializeUpdateMeetingData = (formData: FormType): PatchMeeting['request'] => {
+  const refinedParts = formData.detail.joinableParts
+    .filter((part) => part.value && part.value !== 'all')
+    .map((part) => part.value) as ('PM' | 'DESIGN' | 'IOS' | 'ANDROID' | 'SERVER' | 'WEB')[];
+
+  return {
+    title: formData.title,
+    subTitle: formData.subTitle || undefined,
+    joinInfo:
+      formData.participationMethod == null && formData.participationIntensity == null
+        ? undefined
+        : {
+            meetingType: formData.participationMethod ?? undefined,
+            meetingFrequency: formData.participationIntensity ?? undefined,
+          },
     files: formData.files,
     category: formData.category.value,
     startDate: formData.dateRange[0] ?? '',

--- a/apps/crew/src/api/meeting/type.ts
+++ b/apps/crew/src/api/meeting/type.ts
@@ -15,6 +15,10 @@ export type PostMeeting = {
   response: paths['/meeting/v2']['post']['responses']['201']['content']['application/json;charset=UTF-8'];
 };
 
+export type PatchMeeting = {
+  request: paths['/meeting/v2/{meetingId}']['patch']['requestBody']['content']['application/json;charset=UTF-8'];
+};
+
 export type MeetingData = GetMeetingList['response']['meetings'][number];
 
 export type GetMeetingMemberList = {

--- a/apps/crew/src/constant/index.ts
+++ b/apps/crew/src/constant/index.ts
@@ -1,4 +1,4 @@
 export const THUMBNAIL_IMAGE_INDEX = 0;
 
 // 이 날짜 이전에 개설된 모임은 환영태그(WelcomeMessageField) UI를 유지하고, 이후 개설된 모임은 부제목/참여정보 UI를 사용합니다.
-export const OLD_MEETING_CUTOFF_DATE = new Date('2026-05-02');
+export const OLD_MEETING_CUTOFF_DATE = new Date('2026-05-02T00:00:00+09:00');

--- a/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/Modal/Content/PartStatusModalContent/index.tsx
@@ -6,7 +6,7 @@ interface PartStatusModalContentProps {
 }
 
 const PartStatusModalContent = ({ partMembersData }: PartStatusModalContentProps) => {
-  const memberNames = partMembersData.memberNames ?? [];
+  const memberNames = partMembersData.appliedInfo?.map((info) => info.user.name) ?? [];
   const total = partMembersData.participantCount ?? memberNames.length;
 
   return (
@@ -24,7 +24,7 @@ const PartStatusModalContent = ({ partMembersData }: PartStatusModalContentProps
       )}
       {memberNames.length > 0 && (
         <SModalBottom>
-          <STotal>총 {total}명 신청</STotal>
+          <STotal>{total}명 신청</STotal>
         </SModalBottom>
       )}
     </>

--- a/apps/crew/src/domain/detail/MeetingController/index.tsx
+++ b/apps/crew/src/domain/detail/MeetingController/index.tsx
@@ -65,7 +65,10 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
 
   const { open: dialogOpen, close: dialogClose } = useDialog();
   const { data: me } = useQuery(useUserProfileQueryOption());
-  const { data: partMembersData } = useQuery(useMeetingPartMembersQueryOption({ meetingId: Number(meetingId) }));
+  const { data: partMembersData } = useQuery({
+    ...useMeetingPartMembersQueryOption({ meetingId: Number(meetingId) }),
+    enabled: !isFlash && !!meetingId, // 파트 신청 멤버 기능 flash는 제외, 추후 추가하면 enabled 조건에서 isFlash 제거
+  });
   const queryClient = useQueryClient();
   const router = useRouter();
   const isRecruiting = status === ERecruitmentStatus.RECRUITING;
@@ -278,23 +281,26 @@ const MeetingController = ({ detailData }: DetailHeaderProps) => {
         )}
         <div>
           <SStatusButtonWrapper>
-            <SPartStatusButton onClick={handlePartStatusModal}>
-              <span>
-                <SFireEmoji>🔥 </SFireEmoji>
-                {isActiveGeneration ? (
-                  <>
-                    <SPartName>{partMembersData?.part} 파트</SPartName> {partMembersData?.participantCount ?? 0}명
-                    <SApplyingText> 신청 중</SApplyingText>
-                  </>
-                ) : (
-                  <>
-                    {partMembersData?.activeGeneration}기 멤버 {partMembersData?.participantCount ?? 0}명
-                    <SApplyingText> 신청 중</SApplyingText>
-                  </>
-                )}
-              </span>
-              <ArrowSmallRightIcon />
-            </SPartStatusButton>
+            {/* 파트 신청 멤버 기능 flash는 제외, 추후 추가하면 isFlash 분기 제거  */}
+            {!isFlash && (
+              <SPartStatusButton onClick={handlePartStatusModal}>
+                <span>
+                  <SFireEmoji>🔥 </SFireEmoji>
+                  {isActiveGeneration ? (
+                    <>
+                      <SPartName>{partMembersData?.part} 파트</SPartName> {partMembersData?.participantCount ?? 0}명
+                      <SApplyingText> 신청 중</SApplyingText>
+                    </>
+                  ) : (
+                    <>
+                      {partMembersData?.activeGeneration}기 멤버 {partMembersData?.participantCount ?? 0}명
+                      <SApplyingText> 신청 중</SApplyingText>
+                    </>
+                  )}
+                </span>
+                <ArrowSmallRightIcon />
+              </SPartStatusButton>
+            )}
             <SStatusButton onClick={handleRecruitmentStatusModal}>
               <div>
                 <span>모집 현황</span>

--- a/apps/crew/src/type/form.ts
+++ b/apps/crew/src/type/form.ts
@@ -25,9 +25,9 @@ export const schema = z.object({
     .string()
     .max(30, { message: '30자 까지 입력할 수 있습니다.' })
     .min(1, { message: '모임 제목을 입력해주세요.' }),
-  subTitle: z.string().max(30, { message: '30자 까지 입력할 수 있습니다.' }).optional(),
-  participationMethod: z.enum(['온라인', '오프라인', '온-오프']).optional(),
-  participationIntensity: z.enum(['가볍게', '적당히', '집중형']).optional(),
+  subTitle: z.string().max(30, { message: '30자 까지 입력할 수 있습니다.' }).optional().nullable(),
+  participationMethod: z.enum(['온라인', '오프라인', '온-오프']).optional().nullable(),
+  participationIntensity: z.enum(['가볍게', '적당히', '집중형']).optional().nullable(),
   category: z.object({
     label: z.string(),
     value: z.string({

--- a/apps/crew/src/type/form.ts
+++ b/apps/crew/src/type/form.ts
@@ -20,7 +20,7 @@ export const isOverOneYear = (start?: string, end?: string) => {
   return endDate.isAfter(startDate.add(1, 'year'));
 };
 
-export const schema = z.object({
+export const legacyMeetingEditSchema = z.object({
   title: z
     .string()
     .max(30, { message: '30자 까지 입력할 수 있습니다.' })
@@ -106,7 +106,7 @@ export const schema = z.object({
   }),
 });
 
-export const createSchema = schema.extend({
+export const createSchema = legacyMeetingEditSchema.extend({
   subTitle: z
     .string()
     .max(30, { message: '30자 까지 입력할 수 있습니다.' })
@@ -115,7 +115,9 @@ export const createSchema = schema.extend({
   participationIntensity: z.enum(['가볍게', '적당히', '집중형'], { message: '참여 강도를 선택해주세요.' }),
 });
 
-export type FormType = z.infer<typeof schema>;
+export const newMeetingEditSchema = createSchema;
+
+export type FormType = z.infer<typeof legacyMeetingEditSchema>;
 
 export const MAX_FILE_SIZE = 20 * 1024 ** 2; // 5MB
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,9 +2859,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hookform/devtools@npm:^4.3.1":
-  version: 4.4.0
-  resolution: "@hookform/devtools@npm:4.4.0"
+"@hookform/devtools@npm:4.3.1":
+  version: 4.3.1
+  resolution: "@hookform/devtools@npm:4.3.1"
   dependencies:
     "@emotion/react": "npm:^11.1.5"
     "@emotion/styled": "npm:^11.3.0"
@@ -2872,9 +2872,9 @@ __metadata:
     use-deep-compare-effect: "npm:^1.8.1"
     uuid: "npm:^8.3.2"
   peerDependencies:
-    react: ^16.8.0 || ^17 || ^18 || ^19
-    react-dom: ^16.8.0 || ^17 || ^18 || ^19
-  checksum: 10c0/ad6a7081bfa79b68fd11da45bc9680412fff0e2b450dc022a3405b34c757c514251d3e9b1ca96f167cad4ffa7a649da07c79a69766656d1a44437658079c3aaa
+    react: ^16.8.0 || ^17 || ^18
+    react-dom: ^16.8.0 || ^17 || ^18
+  checksum: 10c0/4155e4c5da69b397e7a0aea9c674def5cb92e9d21f420be6cbb32d3c893a239e890d3a17f8a31fb194493696230806f8d77b8b2be1b7a9c797a3f89477c3c9f5
   languageName: node
   linkType: hard
 
@@ -11376,7 +11376,7 @@ __metadata:
     "@emotion/cache": "npm:^11.9.0"
     "@emotion/server": "npm:^11.9.0"
     "@headlessui/react": "npm:^1.7.3"
-    "@hookform/devtools": "npm:^4.3.1"
+    "@hookform/devtools": "npm:4.3.1"
     "@hookform/resolvers": "npm:^2.9.10"
     "@nanostores/react": "npm:^0.7.1"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.1"


### PR DESCRIPTION
## 📋 작업 내용

- [x] 모임 수정(PATCH) API용 `serializeUpdateMeetingData` 함수 분리 및 `PatchMeeting` 타입 추가
- [x] old 모임 수정 시 `joinInfo` 빈 객체(`{}`) 전송으로 발생하던 400 오류 수정 — `null/undefined`이면 필드 생략 처리
- [x] `subTitle` 빈 문자열 전송으로 발생하던 `@Size(min=1)` 유효성 검사 오류 수정
- [x] schema2 업데이트 — PATCH DTO에 `meetingKeywordTypes` 필드 추가 반영
- [x] `PartStatusModalContent` 응답 구조 변경 대응 (`memberNames` → `appliedInfo[].user.name`)
- [x] flash 상세 페이지에서 파트 신청 현황 버튼 및 API 호출 제외 (`isFlash` 분기)
- [x] flash 상세 조회 쿼리 `enabled` 가드 추가 — 라우터 query 미준비 시 NaN ID 호출 방지

## 📌 PR Point

- `serializeMeetingData`(POST)와 `serializeUpdateMeetingData`(PATCH)를 분리한 이유: PATCH DTO는 모든 필드가 optional이고, `joinInfo`·`subTitle` 등 null 처리 방식이 달라 하나의 함수로 관리하면 `as` 타입 캐스트가 필요했음
- `joinInfo`는 `{}` 전송 시 백엔드 `MeetingJoinInfo` 파싱 실패 → `participationMethod/Intensity`가 모두 null이면 필드 자체를 생략(`undefined`)하도록 처리
- `subTitle` 빈 문자열도 백엔드 `@Size(min=1)` 검사 실패 → `|| undefined`로 falsy값이면 필드 생략
- flash 상세에서 `router.query.id`가 첫 렌더 시 `undefined`라 `+undefined = NaN`으로 API가 나가던 문제 — `enabled: !!meetingId` 추가로 방지 (meeting 쿼리 옵션에는 이미 있었으나 flash에는 누락되어 있었음)
- `PartStatusModalContent`는 스키마 업데이트로 서버 응답 구조가 변경됨 (`memberNames[]` → `appliedInfo[].user.name`)

## 📸 스크린샷

| As-is | To-be |
|-------|-------|
|       |       |

---
🤖 made by [claude](https://claude.ai)
