### PR TITLE
fix: Crew workflow pull_request 트리거에서 불필요한 경로 제거

### DIFF
--- a/.github/workflows/crew-build.yml
+++ b/.github/workflows/crew-build.yml
@@ -1,0 +1,46 @@
+name: Crew - Build App
+
+on:
+  pull_request:
+    paths:
+      - 'apps/crew/**'
+      - 'packages/**'
+      - '.github/workflows/crew-build.yml'
+      - '.yarnrc.yml'
+      - 'package.json'
+      - 'turbo.json'
+      - 'yarn.lock'
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@4.1.1 --activate
+          yarn -v
+
+      - name: Cache Yarn
+        uses: actions/cache@v4
+        id: yarn-cache
+        with:
+          path: ~/.yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Packages
+        run: yarn install --immutable
+
+      - name: Build
+        run: yarn build:crew

--- a/.github/workflows/crew-deploy-development.yml
+++ b/.github/workflows/crew-deploy-development.yml
@@ -8,12 +8,6 @@ on:
       - 'packages/**'
       - 'package.json'
       - 'yarn.lock'
-  pull_request:
-    paths:
-      - 'apps/crew/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'yarn.lock'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/crew-deploy-development.yml
+++ b/.github/workflows/crew-deploy-development.yml
@@ -8,6 +8,12 @@ on:
       - 'packages/**'
       - 'package.json'
       - 'yarn.lock'
+  pull_request:
+    paths:
+      - 'apps/crew/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'yarn.lock'
   workflow_dispatch:
 
 jobs:

--- a/apps/crew/pages/index.tsx
+++ b/apps/crew/pages/index.tsx
@@ -14,7 +14,7 @@ import { styled } from 'stitches.config';
 
 const Home: NextPage = () => {
   const { isLaptop, isTablet } = useDisplay();
-  // 임시 주석
+
   return (
     <>
       <CrewTab>

--- a/apps/crew/pages/index.tsx
+++ b/apps/crew/pages/index.tsx
@@ -14,7 +14,7 @@ import { styled } from 'stitches.config';
 
 const Home: NextPage = () => {
   const { isLaptop, isTablet } = useDisplay();
-
+  // 임시 주석
   return (
     <>
       <CrewTab>


### PR DESCRIPTION
## 📋 작업 내용

- [x] workflow pull_request 트리거에서 불필요한 경로 제거

## 📌 PR Point
기존 `Crew - Development Deploy` 워크플로우는 `push`뿐 아니라 `pull_request` 이벤트에서도 실행되도록 설정되어 있었어요
```yaml
  on:
    push:
      branches: [develop]
    pull_request:
```
이 때문에 feature -> develop PR을 생성하거나 PR에 커밋을 추가했을 때 PR이 아직 머지되지 않았음에도 apps/crew/**, packages/**, package.json, yarn.lock 변경이 포함되어 있으면 Crew development 배포가 실행됐습니다.

결과적으로 `merge`되지 않은 PR 코드가 `internal`에 먼저 반영될 수 있는 문제가 있었습니다.

따라서 `.github/workflows/crew-deploy-development.yml`에서 `pull_request` trigger를 제거하였고 이제는
- develop 브랜치에 push가 발생한 경우 (PR을 merge했을 때)
- 수동으로 workflow_dispatch를 실행한 경우

즉 feature -> develop PR 단계에서는 배포가 실행되지 않고 PR이 머지되어 develop 브랜치에 실제 변경이 들어간 뒤에만 dev 서버에 반영하도록 수정했어요.

++
Crew 앱의 PR build 검증 workflow를 따로 분리해서 Crew 관련 파일, 공용 패키지, build 설정이 변경된 PR에서 `yarn build:crew`를 실행해 develop 머지 전에 build 실패를 확인할 수 있도록 했어요.