### PR TITLE
feat: 모임 목록 배너를 외부 배너 API로 전환

### DIFF
--- a/apps/crew/src/api/banner/BannerQueryKey.ts
+++ b/apps/crew/src/api/banner/BannerQueryKey.ts
@@ -1,0 +1,6 @@
+const BannerQueryKey = {
+  all: () => ['banner'] as const,
+  list: (location: string) => [...BannerQueryKey.all(), location] as const,
+};
+
+export default BannerQueryKey;

--- a/apps/crew/src/api/banner/index.ts
+++ b/apps/crew/src/api/banner/index.ts
@@ -1,0 +1,10 @@
+import type { GetBannersResponse } from '@api/banner/type';
+
+import { operationApi } from '..';
+
+export const getBanners = async (location: string) => {
+  const { data } = await operationApi.get<GetBannersResponse>('/banners/images', {
+    params: { location },
+  });
+  return data;
+};

--- a/apps/crew/src/api/banner/query.ts
+++ b/apps/crew/src/api/banner/query.ts
@@ -1,0 +1,11 @@
+import BannerQueryKey from '@api/banner/BannerQueryKey';
+import { queryOptions } from '@tanstack/react-query';
+
+import { getBanners } from '.';
+
+export const useBannerQueryOption = (location: string) => {
+  return queryOptions({
+    queryKey: BannerQueryKey.list(location),
+    queryFn: () => getBanners(location),
+  });
+};

--- a/apps/crew/src/api/banner/type.ts
+++ b/apps/crew/src/api/banner/type.ts
@@ -1,0 +1,13 @@
+export interface BannerImage {
+  pc_url: string;
+  mobile_url: string;
+  start_date: string;
+  end_date: string;
+  link: string | null;
+}
+
+export interface GetBannersResponse {
+  success: boolean;
+  message: string;
+  data: BannerImage[];
+}

--- a/apps/crew/src/api/index.ts
+++ b/apps/crew/src/api/index.ts
@@ -17,6 +17,8 @@ const authBaseURL = isProduction ? 'https://auth.api.sopt.org' : 'https://auth.a
 
 const playgroundBaseURL = isProduction ? 'https://playground.api.sopt.org/' : 'https://playground.dev.sopt.org/';
 
+const operationBaseURL = process.env.NEXT_PUBLIC_OPERATION_API_URL ?? '';
+
 export const baseApi = axios.create({ baseURL });
 
 export const api = axios.create({
@@ -34,6 +36,15 @@ authToken.subscribe((newToken) => {
 
 export const playgroundApi = axios.create({
   baseURL: playgroundBaseURL,
+});
+
+export const operationApi = axios.create({
+  baseURL: operationBaseURL,
+  headers: {
+    'Accept': '*/*',
+    'Content-Type': 'application/json',
+    'api-key': process.env.NEXT_PUBLIC_ADMIN_KEY ?? '',
+  },
 });
 
 authToken.subscribe((newToken) => {

--- a/apps/crew/src/domain/list/Meeting/MeetingListOfAll.tsx
+++ b/apps/crew/src/domain/list/Meeting/MeetingListOfAll.tsx
@@ -1,4 +1,4 @@
-import { useAdvertisementQueryOption } from '@api/advertisement/query';
+import { useBannerQueryOption } from '@api/banner/query';
 import { useMeetingListQueryOption } from '@api/meeting/query';
 import type { MeetingData } from '@api/meeting/type';
 import { useUserProfileQueryOption } from '@api/user/query';
@@ -8,7 +8,6 @@ import { useDisplay } from '@hook/useDisplay';
 import { useScrollRestorationAfterLoading } from '@hook/useScrollRestoration';
 import { Suspense } from '@suspensive/react';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { AdvertisementCategory } from '@type/advertisement';
 import Link from 'next/link';
 import { useEffect } from 'react';
 import { styled } from 'stitches.config';
@@ -24,18 +23,20 @@ function MeetingListOfAll() {
   const { value: page, setValue: setPage } = usePageParams();
   const { isDesktop } = useDisplay();
   const { data: meetingListData, isLoading } = useSuspenseQuery(useMeetingListQueryOption());
-  const { data: meetingAds } = useSuspenseQuery(useAdvertisementQueryOption(AdvertisementCategory.MEETING));
+  const { data: bannerData } = useSuspenseQuery(useBannerQueryOption('cr_main'));
 
   useScrollRestorationAfterLoading(isLoading);
   const { data: me } = useQuery(useUserProfileQueryOption());
 
+  const banner = bannerData?.data?.[0];
+
   useEffect(() => {
     ampli.impressionBanner({
-      banner_id: meetingAds?.advertisements[0]?.advertisementId,
-      banner_url: meetingAds?.advertisements[0]?.advertisementLink,
-      banner_timestamp: meetingAds?.advertisements[0]?.advertisementStartDate,
+      banner_id: undefined,
+      banner_url: banner?.link ?? undefined,
+      banner_timestamp: banner?.start_date,
     });
-  }, [meetingAds]);
+  }, [banner]);
 
   return (
     <main>
@@ -49,42 +50,42 @@ function MeetingListOfAll() {
               <Card key={meetingData.id} meetingData={meetingData} mobileType='list' />
             ))}
 
-            {meetingAds?.advertisements && meetingListData?.meta.page === 1 && (
-              <Link
-                href={meetingAds?.advertisements[0]?.advertisementLink ?? ''}
-                target='_blank'
-                onClick={() =>
-                  ampli.clickBanner({
-                    banner_id: meetingAds?.advertisements[0]?.advertisementId,
-                    banner_url: meetingAds?.advertisements[0]?.advertisementLink,
-                    banner_timestamp: meetingAds?.advertisements[0]?.advertisementStartDate,
-                    user_id: Number(me?.orgId),
-                  })
-                }
-              >
-                {isDesktop ? (
+            {banner &&
+              meetingListData?.meta.page === 1 &&
+              (() => {
+                const bannerImage = isDesktop ? (
                   <img
-                    src={meetingAds?.advertisements[0]?.desktopImageUrl}
-                    style={{
-                      width: '380px',
-                      height: '506px',
-                      borderRadius: '12px',
-                    }}
+                    src={banner.pc_url}
+                    style={{ width: '380px', height: '506px', borderRadius: '12px', objectFit: 'cover' }}
                     alt='광고 구좌 이미지'
-                  ></img>
+                  />
                 ) : (
                   <img
-                    src={meetingAds?.advertisements[0]?.mobileImageUrl}
-                    style={{
-                      width: '100%',
-                      height: '92px',
-                      borderRadius: '8px',
-                    }}
+                    src={banner.mobile_url}
+                    style={{ width: '100%', height: '92px', borderRadius: '8px', objectFit: 'cover' }}
                     alt='광고 구좌 이미지'
-                  ></img>
-                )}
-              </Link>
-            )}
+                  />
+                );
+
+                return banner.link ? (
+                  <Link
+                    href={banner.link}
+                    target='_blank'
+                    onClick={() =>
+                      ampli.clickBanner({
+                        banner_id: undefined,
+                        banner_url: banner.link ?? undefined,
+                        banner_timestamp: banner.start_date,
+                        user_id: Number(me?.orgId),
+                      })
+                    }
+                  >
+                    {bannerImage}
+                  </Link>
+                ) : (
+                  bannerImage
+                );
+              })()}
             {meetingListData?.meetings.slice(2).map((meetingData) => (
               <Card key={meetingData.id} meetingData={meetingData} mobileType='list' />
             ))}
@@ -127,9 +128,7 @@ const PaginationWrapper = styled('div', {
 
 const SMeetingCountWrapper = styled('div', {
   'display': 'flex',
-  '@media (max-width: 849px)': {
-    justifyContent: 'center',
-  },
+
   '@new_mobile': { mt: '$28' },
   '@new_tablet': { mt: '$40' },
   '@new_desktop': { mt: '$40' },

--- a/apps/crew/src/domain/list/Meeting/MeetingListOfAll.tsx
+++ b/apps/crew/src/domain/list/Meeting/MeetingListOfAll.tsx
@@ -52,40 +52,32 @@ function MeetingListOfAll() {
 
             {banner &&
               meetingListData?.meta.page === 1 &&
-              (() => {
-                const bannerImage = isDesktop ? (
-                  <img
-                    src={banner.pc_url}
-                    style={{ width: '380px', height: '506px', borderRadius: '12px', objectFit: 'cover' }}
+              (banner.link ? (
+                <Link
+                  href={banner.link}
+                  target='_blank'
+                  onClick={() =>
+                    ampli.clickBanner({
+                      banner_id: undefined,
+                      banner_url: banner.link ?? undefined,
+                      banner_timestamp: banner.start_date,
+                      user_id: Number(me?.orgId),
+                    })
+                  }
+                >
+                  <SBannerImage
+                    src={isDesktop ? banner.pc_url : banner.mobile_url}
                     alt='광고 구좌 이미지'
+                    isDesktop={isDesktop}
                   />
-                ) : (
-                  <img
-                    src={banner.mobile_url}
-                    style={{ width: '100%', height: '92px', borderRadius: '8px', objectFit: 'cover' }}
-                    alt='광고 구좌 이미지'
-                  />
-                );
-
-                return banner.link ? (
-                  <Link
-                    href={banner.link}
-                    target='_blank'
-                    onClick={() =>
-                      ampli.clickBanner({
-                        banner_id: undefined,
-                        banner_url: banner.link ?? undefined,
-                        banner_timestamp: banner.start_date,
-                        user_id: Number(me?.orgId),
-                      })
-                    }
-                  >
-                    {bannerImage}
-                  </Link>
-                ) : (
-                  bannerImage
-                );
-              })()}
+                </Link>
+              ) : (
+                <SBannerImage
+                  src={isDesktop ? banner.pc_url : banner.mobile_url}
+                  alt='광고 구좌 이미지'
+                  isDesktop={isDesktop}
+                />
+              ))}
             {meetingListData?.meetings.slice(2).map((meetingData) => (
               <Card key={meetingData.id} meetingData={meetingData} mobileType='list' />
             ))}
@@ -133,6 +125,16 @@ const SMeetingCountWrapper = styled('div', {
   '@new_tablet': { mt: '$40' },
   '@new_desktop': { mt: '$40' },
   '@new_laptop': { mt: '$40' },
+});
+
+const SBannerImage = styled('img', {
+  objectFit: 'cover',
+  variants: {
+    isDesktop: {
+      true: { width: '380px', height: '506px', borderRadius: '12px' },
+      false: { width: '100%', height: '92px', borderRadius: '8px' },
+    },
+  },
 });
 
 const SMeetingCount = styled('p', {


### PR DESCRIPTION
## 📋 작업 내용

- [x] 외부 배너 API(`/banners/images`) 연동을 위한 `operationApi` axios 인스턴스 추가
- [x] 배너 관련 API 레이어 신규 구현 (`BannerQueryKey`, `getBanners`, `useBannerQueryOption`, 타입 정의)
- [x] 모임 목록 배너를 기존 내부 광고 API(`useAdvertisementQueryOption`)에서 외부 배너 API로 전환
- [x] 배너 링크가 없는 경우 `<Link>` 없이 이미지만 렌더링하도록 처리
- [x] Crew PR 빌드 체크용 GitHub Actions 워크플로우(`crew-build.yml`) 추가
- [x] 배포 워크플로우(`crew-deploy-development.yml`)에서 불필요한 `pull_request` 트리거 제거

## 📌 PR Point

- 기존 광고 API(`AdvertisementCategory.MEETING`)가 외부 배너 API로 교체됨에 따라 응답 스키마가 변경되었습니다. (`advertisementLink` → `link`, `desktopImageUrl` → `pc_url`, `mobileImageUrl` → `mobile_url` 등)
- `operationApi`는 `NEXT_PUBLIC_OPERATION_API_URL`, `NEXT_PUBLIC_ADMIN_KEY` 환경변수를 사용합니다. 배포 환경에 해당 환경변수가 설정되어 있는지 확인이 필요합니다.
- ampli 배너 트래킹에서 `banner_id`는 외부 API에 해당 필드가 없어 `undefined`로 처리하였습니다. 트래킹 데이터 정합성에 영향이 있을 수 있어 확인 부탁드립니다.
- 배너 링크가 `null`인 경우 클릭 불가 이미지로만 노출되도록 분기 처리했습니다.

## 📸 스크린샷
<img width="3420" height="1798" alt="image (6)" src="https://github.com/user-attachments/assets/a8247c6b-1e51-4e28-abc6-54b08587431f" />


---
🤖 made by [claude](https://claude.ai)
