### PR TITLE
feat: 홈 미리보기 섹션 레이아웃 구현

### DIFF
--- a/apps/playground/src/components/home/common/MenuLink.tsx
+++ b/apps/playground/src/components/home/common/MenuLink.tsx
@@ -15,30 +15,30 @@ import type { MenuKey } from './MenuPreview';
 
 interface MenuMeta {
   href: string;
-  Icon: ReactNode;
-  title: '멤버' | '커뮤니티' | '프로젝트' | '커피솝';
+  leftAddon: ReactNode;
+  label: '멤버' | '커뮤니티' | '프로젝트' | '커피솝';
 }
 
 const MENU_CONFIG: Record<MenuKey, MenuMeta> = {
   members: {
     href: playgroundLink.memberList(),
-    Icon: <MemberIcon width={18} height={18} />,
-    title: '멤버',
+    leftAddon: <MemberIcon width={18} height={18} />,
+    label: '멤버',
   },
   feed: {
     href: playgroundLink.feedList(),
-    Icon: <FeedIcon width={18} height={18} />,
-    title: '커뮤니티',
+    leftAddon: <FeedIcon width={18} height={18} />,
+    label: '커뮤니티',
   },
   projects: {
     href: playgroundLink.projectList(),
-    Icon: <ProjectIcon width={18} height={18} />,
-    title: '프로젝트',
+    leftAddon: <ProjectIcon width={18} height={18} />,
+    label: '프로젝트',
   },
   coffeechat: {
     href: playgroundLink.coffeechat(),
-    Icon: <CoffeeChatIcon width={18} height={18} />,
-    title: '커피솝',
+    leftAddon: <CoffeeChatIcon width={18} height={18} />,
+    label: '커피솝',
   },
 };
 
@@ -47,12 +47,12 @@ interface MenuLinkProps {
 }
 
 const MenuLink = ({ menu }: MenuLinkProps) => {
-  const { href, Icon, title } = MENU_CONFIG[menu];
+  const { href, leftAddon, label } = MENU_CONFIG[menu];
 
   return (
     <StyledLink href={href}>
-      {Icon}
-      <StyledTitle>{title} &gt;</StyledTitle>
+      {leftAddon}
+      <StyledLabel>{label} &gt;</StyledLabel>
     </StyledLink>
   );
 };
@@ -64,7 +64,7 @@ const StyledLink = styled(Link)`
   cursor: pointer;
 `;
 
-const StyledTitle = styled.span`
+const StyledLabel = styled.span`
   color: ${colors.gray100};
   ${fonts.BODY_16_M}
 

--- a/apps/playground/src/components/home/common/MenuLink.tsx
+++ b/apps/playground/src/components/home/common/MenuLink.tsx
@@ -1,0 +1,76 @@
+import styled from '@emotion/styled';
+import { playgroundLink } from '@sopt/constant';
+import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import CoffeeChatIcon from '@/public/icons/menuEntry/icon-coffeechat.svg';
+import FeedIcon from '@/public/icons/menuEntry/icon-feed.svg';
+import MemberIcon from '@/public/icons/menuEntry/icon-member.svg';
+import ProjectIcon from '@/public/icons/menuEntry/icon-project.svg';
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+import type { MenuKey } from './MenuPreview';
+
+interface MenuMeta {
+  href: string;
+  Icon: ReactNode;
+  title: '멤버' | '커뮤니티' | '프로젝트' | '커피솝';
+}
+
+const MENU_CONFIG: Record<MenuKey, MenuMeta> = {
+  members: {
+    href: playgroundLink.memberList(),
+    Icon: <MemberIcon width={18} height={18} />,
+    title: '멤버',
+  },
+  feed: {
+    href: playgroundLink.feedList(),
+    Icon: <FeedIcon width={18} height={18} />,
+    title: '커뮤니티',
+  },
+  projects: {
+    href: playgroundLink.projectList(),
+    Icon: <ProjectIcon width={18} height={18} />,
+    title: '프로젝트',
+  },
+  coffeechat: {
+    href: playgroundLink.coffeechat(),
+    Icon: <CoffeeChatIcon width={18} height={18} />,
+    title: '커피솝',
+  },
+};
+
+interface MenuLinkProps {
+  menu: MenuKey;
+}
+
+const MenuLink = ({ menu }: MenuLinkProps) => {
+  const { href, Icon, title } = MENU_CONFIG[menu];
+
+  return (
+    <StyledLink href={href}>
+      {Icon}
+      <StyledTitle>{title} &gt;</StyledTitle>
+    </StyledLink>
+  );
+};
+
+const StyledLink = styled(Link)`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+`;
+
+const StyledTitle = styled.span`
+  color: ${colors.gray100};
+  ${fonts.BODY_16_M}
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    ${fonts.BODY_14_M}
+  }
+`;
+
+export default MenuLink;

--- a/apps/playground/src/components/home/common/MenuPreview.tsx
+++ b/apps/playground/src/components/home/common/MenuPreview.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import type { ReactNode } from 'react';
+
+import MenuLink from './MenuLink';
+
+export type MenuKey = 'members' | 'feed' | 'projects' | 'coffeechat';
+
+interface MenuPreviewProps {
+  menu: MenuKey;
+  content: ReactNode;
+  className?: string;
+}
+
+const MenuPreview = ({ menu, content, className }: MenuPreviewProps) => {
+  return (
+    <StyledContainer className={className}>
+      <MenuLink menu={menu} />
+      {content}
+    </StyledContainer>
+  );
+};
+
+export default MenuPreview;
+
+const StyledContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;

--- a/apps/playground/src/components/home/index.tsx
+++ b/apps/playground/src/components/home/index.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+
+import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
+import MenuPreview from './common/MenuPreview';
+
+const HomePage = () => {
+  return (
+    // TODO: content 교체
+    <StyledContainer>
+      <MemberAndCommunity>
+        <MembersPreview menu={'members'} content={<div>내용</div>} />
+        <CommunityPreview menu={'feed'} content={<div>내용</div>} />
+      </MemberAndCommunity>
+      <MenuPreview menu={'projects'} content={<div>내용</div>} />
+      <MenuPreview menu={'coffeechat'} content={<div>내용</div>} />
+    </StyledContainer>
+  );
+};
+
+export default HomePage;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 60px;
+  width: 1312px;
+  padding-bottom: 142px;
+  margin: 0 auto;
+
+  @media ${DESKTOP_ONE_MEDIA_QUERY} {
+    width: 978px;
+  }
+
+  @media ${DESKTOP_TWO_MEDIA_QUERY} {
+    width: 644px;
+  }
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 44px;
+    width: 100%;
+    padding: 16px 20px 96px 20px;
+  }
+`;
+
+const MemberAndCommunity = styled.div`
+  display: flex;
+  gap: 24px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    flex-direction: column;
+    gap: 44px;
+  }
+`;
+
+const MembersPreview = styled(MenuPreview)`
+  width: 296px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    width: 100%;
+  }
+`;
+
+const CommunityPreview = styled(MenuPreview)`
+  flex: 1;
+`;

--- a/apps/playground/src/components/members/main/MemberList/OnBoardingBanner.tsx
+++ b/apps/playground/src/components/members/main/MemberList/OnBoardingBanner.tsx
@@ -8,8 +8,7 @@ import type { FC } from 'react';
 import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
-import { DESKTOP_TWO_MEDIA_QUERY } from '@/components/members/main/contants';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { textStyles } from '@/styles/typography';
 
 interface OnBoardingBannerProps {

--- a/apps/playground/src/components/members/main/MemberList/WorkPreferenceMatchedMemberList.tsx
+++ b/apps/playground/src/components/members/main/MemberList/WorkPreferenceMatchedMemberList.tsx
@@ -13,11 +13,10 @@ import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import { convertWorkPreferenceToHashtags } from '@/components/matchmember/constant';
 import { useMatchMemberEvent } from '@/components/matchmember/hooks/useMatchMemberEvent';
 import MatchMemberModal from '@/components/matchmember/MatchMemberModal';
-import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY } from '@/components/members/main/contants';
 import WorkPreferenceMemberCard from '@/components/members/main/MemberCard/WorkPreferneceMemberCard';
 import { mockRecommendationsResponse } from '@/components/members/main/MemberList/constants';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 const MyPreferenceSubTitle = () => {
   const { data: myData, isLoading: myLoading } = useGetMyWorkPreference();

--- a/apps/playground/src/components/members/main/MemberList/index.tsx
+++ b/apps/playground/src/components/members/main/MemberList/index.tsx
@@ -19,7 +19,6 @@ import Responsive from '@/components/common/Responsive';
 import Text from '@/components/common/Text';
 import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import MessageModal, { MessageCategory } from '@/components/members/detail/MessageSection/MessageModal';
-import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY } from '@/components/members/main/contants';
 import { useMemberProfileQuery } from '@/components/members/main/hooks/useMemberProfileQuery';
 import MemberCard from '@/components/members/main/MemberCard';
 import type { Option } from '@/components/members/main/MemberList/filters/constants';
@@ -43,7 +42,7 @@ import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import { usePageQueryParams } from '@/hooks/usePageQueryParams';
 import { useRunOnce } from '@/hooks/useRunOnce';
 import IconDiagonalArrow from '@/public/icons/icon-diagonal-arrow.svg';
-import { MB_BIG_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY, MB_BIG_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import AskCardList from '../AskCardList/AskCardList';

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -10,10 +10,9 @@ import { useGetMemberRecommendOfMe } from '@/api/endpoint/members/getMemberRecom
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import MemberRecommendCard from '../../common/MemberRecommendCard/MemberRecommendCard';
-import { DESKTOP_TWO_MEDIA_QUERY } from '../contants';
 
 const PC_MEDIA_WIDTH = 1200;
 const PC_MEDIA_QUERY = `screen and (min-width: ${PC_MEDIA_WIDTH}px)`;
@@ -160,7 +159,7 @@ const TooltipArrow = styled.div`
 
 const StyledCardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
 
   & > *:nth-child(n + 5) {
@@ -168,7 +167,7 @@ const StyledCardGrid = styled.div`
   }
 
   @media ${DESKTOP_TWO_MEDIA_QUERY} {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
 
     & > *:nth-child(n + 4) {

--- a/apps/playground/src/components/members/main/contants.ts
+++ b/apps/playground/src/components/members/main/contants.ts
@@ -1,2 +1,0 @@
-export const DESKTOP_ONE_MEDIA_QUERY = 'screen and (max-width: 1542px)';
-export const DESKTOP_TWO_MEDIA_QUERY = 'screen and (max-width: 1200px)';

--- a/apps/playground/src/pages/index.tsx
+++ b/apps/playground/src/pages/index.tsx
@@ -5,7 +5,7 @@ import ActiveBannerSlot from '@/components/common/Banner/ActiveBannerSlot';
 import HomePopupContainer from '@/components/common/HomePopup/HomePopupContainer';
 import Responsive from '@/components/common/Responsive';
 import MenuEntryIcons from '@/components/feed/list/MenuEntryIcons/MenuEntryIcons';
-import FeedHomePage from '@/components/feed/page/FeedHomePage';
+import HomePage from '@/components/home';
 import { setLayout } from '@/utils/layout';
 
 const Home: NextPage = () => {
@@ -16,7 +16,7 @@ const Home: NextPage = () => {
       <Responsive only='mobile'>
         <MenuEntryIcons />
       </Responsive>
-      <FeedHomePage />
+      <HomePage />
     </AuthRequired>
   );
 };

--- a/apps/playground/src/pages/members/team-leaders.tsx
+++ b/apps/playground/src/pages/members/team-leaders.tsx
@@ -6,10 +6,8 @@ import { useState } from 'react';
 
 import AuthRequired from '@/components/auth/AuthRequired';
 import Text from '@/components/common/Text';
-import { DESKTOP_ONE_MEDIA_QUERY } from '@/components/members/main/contants';
-import { DESKTOP_TWO_MEDIA_QUERY } from '@/components/members/main/contants';
 import TeamLeaderCard from '@/components/members/main/TeamLeaderCard';
-import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 import { setLayout } from '@/utils/layout';
 type SelectedPart = 'APP' | 'WEB';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';

--- a/apps/playground/src/styles/mediaQuery.ts
+++ b/apps/playground/src/styles/mediaQuery.ts
@@ -18,3 +18,8 @@ export const MB_BASE_MEDIA_QUERY = `screen and (max-width: ${MB_BASE_WIDTH}px)`;
 export const MB_MID_MEDIA_QUERY = `screen and (max-width: ${MB_MID_WIDTH}px)`;
 export const MB_SM_MEDIA_QUERY = `screen and (max-width: ${MB_SM_WIDTH}px)`;
 export const PCTA_S_MEDIA_QUERY = `screen and (max-width: ${PCTA_S_WIDTH}px)`;
+// TODO: 네이밍 통일 필요
+export const DESKTOP_ONE_MAX_WIDTH = 1542;
+export const DESKTOP_TWO_MAX_WIDTH = 1200;
+export const DESKTOP_ONE_MEDIA_QUERY = `screen and (max-width: ${DESKTOP_ONE_MAX_WIDTH}px)`;
+export const DESKTOP_TWO_MEDIA_QUERY = `screen and (max-width: ${DESKTOP_TWO_MAX_WIDTH}px)`;


### PR DESCRIPTION
## 📋 작업 내용

- [x] 홈 페이지에 쓰일 미리보기 섹션 큰 틀 구현
- [x] 홈 페이지 레이아웃 구현

## 📌 PR Point
- 멤버 페이지에서만 쓰이던 브레이크포인트(~1542px, ~1200px)가 홈 페이지에서도 쓰여서 `mediaQuery.ts` 내부로 이동했어요.
    - 기존 위치: `components/members/main/contants.ts`
    - `mediaQuery.ts` 내부에 네이밍 통일이 필요해 보이는데, 변경점이 많이 생길 것 같아서 따로 이슈 파서 작업할 예정입니다.


## 📸 스크린샷
[desktop]
<img width="3024" height="1038" alt="image" src="https://github.com/user-attachments/assets/9f16b5b1-aaa7-417a-b4df-f1b53648151d" />
[mobile]
<img width="542" height="528" alt="image" src="https://github.com/user-attachments/assets/d8a50a96-410b-4446-ab3a-f1f192cce5c4" />
