### PR TITLE
feat: 프로젝트 카드에 앰플리튜드 로깅 추가 및 이동 로직 추가

### DIFF
--- a/apps/playground/src/components/eventLogger/events.ts
+++ b/apps/playground/src/components/eventLogger/events.ts
@@ -69,6 +69,9 @@ export interface ClickEvents {
 
   // ==== 멤버 ====
   memberCard: MemberCard;
+  memberRecommendRefresh: {
+    screen: 'memberTab' | 'profile';
+  };
   // 멤버 리스트 - 필터
   filterGeneration: {
     generation: string;
@@ -114,7 +117,10 @@ export interface ClickEvents {
   editProfile: undefined;
 
   // ==== 프로젝트 ====
-  projectCard: { id: number };
+  projectCard: {
+    projectId: number;
+    referral: 'home' | 'projectTab';
+  };
   projectUpload: {
     referral: string;
   };
@@ -385,6 +391,12 @@ export interface PageViewEvents {
 export interface ImpressionEvents {
   // ==== 멤버 ====
   memberCard: MemberCard;
+
+  // ==== 프로젝트 ====
+  projectCard: {
+    projectId: number;
+    screen: 'home';
+  };
 
   // ==== 커뮤니티(피드) ====
   feedCard: {

--- a/apps/playground/src/components/home/ProjectPreview/ProjectCard.tsx
+++ b/apps/playground/src/components/home/ProjectPreview/ProjectCard.tsx
@@ -1,10 +1,14 @@
 import styled from '@emotion/styled';
+import { playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import dayjs from 'dayjs';
+import Link from 'next/link';
 
 import type { RandomProject } from '@/api/endpoint/menuPreview/getRandomProjects';
 import ResizedImage from '@/components/common/ResizedImage';
+import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
+import { LoggingImpression } from '@/components/eventLogger/components/LoggingImpression';
 
 import ProjectStatus from './ProjectStatus';
 
@@ -26,33 +30,39 @@ const ProjectCard = ({ project }: ProjectCardProps) => {
   const hasStatus = project.isAvailable || project.isFounding;
 
   return (
-    <StyledContainer>
-      <StyledImage height={180} src={project.thumbnailImage} alt='프로젝트_이미지' />
-      <StyledBody>
-        <StyledImage height={56} src={project.logoImage} alt='팀_로고_이미지' isLogo={true} />
-        <StyledInfo>
-          <StyledTitleGroup>
-            <StyledCategory>
-              <span>
-                {project.generation && `${project.generation}기`} {project.category}
-              </span>
-              <StyledDot>∙</StyledDot>
-              <StyledPlatform>{project.serviceType.join('/')}</StyledPlatform>
-            </StyledCategory>
-            <StyledTitle>{project.name}</StyledTitle>
-          </StyledTitleGroup>
-          <StyledStatusGroup>
-            <StyledDuration>{dateIntoMonthPeriod(project.startAt, project.endAt)}</StyledDuration>
-            {hasStatus && (
-              <StyledStatus>
-                {project.isAvailable && <ProjectStatus>서비스 이용 가능</ProjectStatus>}
-                {project.isFounding && <ProjectStatus>창업 중</ProjectStatus>}
-              </StyledStatus>
-            )}
-          </StyledStatusGroup>
-        </StyledInfo>
-      </StyledBody>
-    </StyledContainer>
+    <LoggingImpression eventKey='projectCard' param={{ projectId: project.id, screen: 'home' }}>
+      <LoggingClick eventKey='projectCard' param={{ projectId: project.id, referral: 'home' }}>
+        <Link href={playgroundLink.projectDetail(project.id)}>
+          <StyledContainer>
+            <StyledImage height={180} src={project.thumbnailImage} alt='프로젝트_이미지' />
+            <StyledBody>
+              <StyledImage height={56} src={project.logoImage} alt='팀_로고_이미지' isLogo={true} />
+              <StyledInfo>
+                <StyledTitleGroup>
+                  <StyledCategory>
+                    <span>
+                      {project.generation && `${project.generation}기`} {project.category}
+                    </span>
+                    <StyledDot>∙</StyledDot>
+                    <StyledPlatform>{project.serviceType.join('/')}</StyledPlatform>
+                  </StyledCategory>
+                  <StyledTitle>{project.name}</StyledTitle>
+                </StyledTitleGroup>
+                <StyledStatusGroup>
+                  <StyledDuration>{dateIntoMonthPeriod(project.startAt, project.endAt)}</StyledDuration>
+                  {hasStatus && (
+                    <StyledStatus>
+                      {project.isAvailable && <ProjectStatus>서비스 이용 가능</ProjectStatus>}
+                      {project.isFounding && <ProjectStatus>창업 중</ProjectStatus>}
+                    </StyledStatus>
+                  )}
+                </StyledStatusGroup>
+              </StyledInfo>
+            </StyledBody>
+          </StyledContainer>
+        </Link>
+      </LoggingClick>
+    </LoggingImpression>
   );
 };
 
@@ -64,6 +74,7 @@ const StyledContainer = styled.div`
   height: 302px;
   border-radius: 12px;
   background-color: ${colors.gray900};
+  cursor: pointer;
 `;
 
 const StyledImage = styled(ResizedImage)<{ isLogo?: boolean }>`
@@ -106,7 +117,11 @@ const StyledDot = styled.span`
   color: ${colors.gray400};
 `;
 
-const StyledPlatform = styled(StyledDot)``;
+const StyledPlatform = styled(StyledDot)`
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
 
 const StyledTitle = styled.div`
   overflow: hidden;

--- a/apps/playground/src/components/home/ProjectPreview/index.tsx
+++ b/apps/playground/src/components/home/ProjectPreview/index.tsx
@@ -18,37 +18,37 @@ const ProjectPreview = () => {
   const isMobile = useMediaQuery(MOBILE_MAX_WIDTH);
   const itemsPerView = isMobile ? 1 : 2;
 
-  if (isLoading) {
-    return (
-      <ProjectSkeletonList aria-hidden>
-        {Array.from({ length: SKELETON_CARD_COUNT }, (_, index) => (
-          <ProjectCardSkeleton key={index} />
-        ))}
-      </ProjectSkeletonList>
-    );
-  }
-
   return (
     <TitledContent title={`지난 기수 앱잼 프로젝트`}>
-      {/* ~1200: 캐러셀 (모바일 1장 / 태블릿 2장) */}
-      <CarouselWrapper>
-        <ScrollCarousel
-          itemCount={projects.length}
-          itemsPerView={itemsPerView}
-          autoPlay={{ enabled: true, interval: 3000 }}
-        >
-          {getLoopedItems(projects, itemsPerView).map((project, index) => (
-            <ProjectCard key={`${project.id}-${index}`} project={project} />
+      {isLoading ? (
+        <ProjectSkeletonList aria-hidden>
+          {Array.from({ length: SKELETON_CARD_COUNT }, (_, index) => (
+            <ProjectCardSkeleton key={index} />
           ))}
-        </ScrollCarousel>
-      </CarouselWrapper>
+        </ProjectSkeletonList>
+      ) : (
+        <>
+          {/* ~1200: 캐러셀 (모바일 1장 / 태블릿 2장) */}
+          <CarouselWrapper>
+            <ScrollCarousel
+              itemCount={projects.length}
+              itemsPerView={itemsPerView}
+              autoPlay={{ enabled: true, interval: 3000 }}
+            >
+              {getLoopedItems(projects, itemsPerView).map((project, index) => (
+                <ProjectCard key={`${project.id}-${index}`} project={project} />
+              ))}
+            </ScrollCarousel>
+          </CarouselWrapper>
 
-      {/* 1200~: 캐러셀 없이 카드 3장 고정 */}
-      <StaticGrid>
-        {projects.map((project) => (
-          <ProjectCard key={`static-${project.id}`} project={project} />
-        ))}
-      </StaticGrid>
+          {/* 1200~: 캐러셀 없이 카드 3장 고정 */}
+          <StaticGrid>
+            {projects.map((project) => (
+              <ProjectCard key={`static-${project.id}`} project={project} />
+            ))}
+          </StaticGrid>
+        </>
+      )}
     </TitledContent>
   );
 };

--- a/apps/playground/src/components/projects/main/ProjectList.tsx
+++ b/apps/playground/src/components/projects/main/ProjectList.tsx
@@ -153,7 +153,7 @@ const ProjectList = () => {
                 return (
                   <React.Fragment key={project.id}>
                     <Responsive only='desktop' asChild>
-                      <LoggingClick eventKey='projectCard' param={{ id: project.id }}>
+                      <LoggingClick eventKey='projectCard' param={{ projectId: project.id, referral: 'projectTab' }}>
                         <Link href={playgroundLink.projectDetail(project.id)}>
                           <ProjectCard
                             key={project.id}
@@ -169,7 +169,7 @@ const ProjectList = () => {
                       </LoggingClick>
                     </Responsive>
                     <Responsive only='mobile' asChild>
-                      <LoggingClick eventKey='projectCard' param={{ id: project.id }}>
+                      <LoggingClick eventKey='projectCard' param={{ projectId: project.id, referral: 'projectTab' }}>
                         <Link href={playgroundLink.projectDetail(project.id)}>
                           <MobileProjectCard
                             key={project.id}


### PR DESCRIPTION
## 📋 작업 내용

- [x] 프로젝트 카드 클릭 시 해당 프로젝트 상세 페이지로 이동 로직 추가
- [x] 홈 > 프로젝트 카드에 impression, click 이벤트 추가
- [x] 프로젝트 탭 > 프로젝트 카드 click 이벤트에 referral 속성 추가

## 📌 PR Point

- 프로젝트 카드 작업 시 누락되었던 앰플리튜드 로깅 및 이동 로직 추가했어요.

## 📸 스크린샷
**[impression-projectCard]**
<img width="354" height="307" alt="image" src="https://github.com/user-attachments/assets/10b67a6f-b189-41ed-92c7-828982656657" />

**[click-projectCard]**
홈
<img width="351" height="98" alt="image" src="https://github.com/user-attachments/assets/22329e88-d91f-454c-8976-36f8fe202c2f" />

프로젝트 탭
<img width="350" height="91" alt="image" src="https://github.com/user-attachments/assets/300b0689-eff7-446d-9590-30513ed7594f" />
