### PR TITLE
style: 홈 페이지 요소 전체적인 스타일 수정

### DIFF
--- a/apps/playground/src/components/common/ScrollCarousel/index.tsx
+++ b/apps/playground/src/components/common/ScrollCarousel/index.tsx
@@ -8,9 +8,16 @@ const ITEM_GAP = 12;
 
 interface ScrollCarouselProps extends UseScrollCarouselOptions {
   children: ReactNode;
+  indicatorOffset?: number;
 }
 
-const ScrollCarousel = ({ itemCount, itemsPerView = 1, autoPlay, children }: ScrollCarouselProps) => {
+const ScrollCarousel = ({
+  itemCount,
+  itemsPerView = 1,
+  autoPlay,
+  children,
+  indicatorOffset = 20,
+}: ScrollCarouselProps) => {
   const { containerRef, pageCount, activePage, scrollToPage } = useScrollCarousel({
     itemCount,
     itemsPerView,
@@ -18,7 +25,7 @@ const ScrollCarousel = ({ itemCount, itemsPerView = 1, autoPlay, children }: Scr
   });
 
   return (
-    <StyledContainer>
+    <StyledContainer gap={indicatorOffset}>
       <StyledViewport ref={containerRef}>
         <StyledTrack>
           {Children.map(children, (child) => (
@@ -37,10 +44,10 @@ const ScrollCarousel = ({ itemCount, itemsPerView = 1, autoPlay, children }: Scr
 
 export default ScrollCarousel;
 
-const StyledContainer = styled.div`
+const StyledContainer = styled.div<{ gap: number }>`
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: ${({ gap }) => `${gap}px`};
   width: 100%;
 `;
 

--- a/apps/playground/src/components/feed/home/RecentArea/FeedIcon.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/FeedIcon.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
+import { fonts } from '@sopt-makers/fonts';
 import { IconHeart } from '@sopt-makers/icons';
 
 import MessageIc from '@/public/icons/icon-message-square.svg';
@@ -23,8 +24,8 @@ const FeedIcon = ({ type, count }: FeedIconProps) => {
 
   return (
     <FeedIconLayout>
-      <Icon width={16} height={16} color={colors.gray400} />
-      {count}
+      <Icon width={14} height={14} color={colors.gray400} />
+      <StyledCount>{count}</StyledCount>
     </FeedIconLayout>
   );
 };
@@ -33,6 +34,11 @@ export default FeedIcon;
 
 const FeedIconLayout = styled.div`
   display: flex;
-  gap: 4px;
+  gap: 2px;
   align-items: center;
+`;
+
+const StyledCount = styled.div`
+  color: ${colors.gray400};
+  ${fonts.LABEL_12_SB}
 `;

--- a/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
@@ -92,6 +92,7 @@ const CardContent = styled.div`
 
 const CardTitle = styled.div`
   display: flex;
+  align-items: center;
   gap: 6px;
 `;
 

--- a/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
+import { Tag } from '@sopt-makers/ui';
 import { useRouter } from 'next/router';
 
 import type { RecentPosts } from '@/api/endpoint/feed/getRecentPosts';
@@ -31,10 +32,12 @@ const RecentCard = ({ recentPost, onClick }: RecentCardProps) => {
     >
       <CardContainer onClick={onClick}>
         <CardContent>
-          <TitleStyle>
-            <Tag>{categoryTagLabel}</Tag>
-            {title}
-          </TitleStyle>
+          <CardTitle>
+            <StyledTag size='sm' variant='primary' shape='rect'>
+              {categoryTagLabel}
+            </StyledTag>
+            <TitleStyle>{title}</TitleStyle>
+          </CardTitle>
           <ContentStyle>{parseMentionsToJSX(content, router)}</ContentStyle>
         </CardContent>
 
@@ -67,6 +70,7 @@ export default RecentCard;
 const CardContainer = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   gap: 12px;
   border-radius: 12px;
   background-color: ${colors.gray900};
@@ -77,26 +81,37 @@ const CardContainer = styled.div`
   &:hover {
     background-color: ${colors.gray800};
   }
+  overflow: hidden;
 `;
 
 const CardContent = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  min-width: 240px;
-  width: 100%;
+`;
+
+const CardTitle = styled.div`
+  display: flex;
+  gap: 6px;
+`;
+
+const StyledTag = styled(Tag)`
+  flex-shrink: 0;
 `;
 
 const TitleStyle = styled(Text)`
+  color: ${colors.gray10};
   ${fonts.TITLE_16_SB}
 
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  min-width: 0;
 `;
 
 const ContentStyle = styled(Text)`
-  ${fonts.BODY_14_L}
+  color: ${colors.gray10};
+  ${fonts.BODY_13_L}
 
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -118,20 +133,7 @@ const FeedIconBox = styled.div`
 
 const CreatedDate = styled(Text)`
   color: ${colors.gray400};
-  ${fonts.LABEL_14_SB}
-`;
-
-const Tag = styled.span`
-  display: inline-flex;
-  width: fit-content;
-  height: 20px;
-  border-radius: 4px;
-  background-color: ${colors.orangeAlpha200};
-  color: ${colors.secondary};
-  ${fonts.LABEL_11_SB}
-  padding: 3px 6px;
-  margin-right: 6px;
-  transform: translateY(-1.5px);
+  ${fonts.LABEL_12_SB}
 `;
 
 const FlexBox = styled.div`

--- a/apps/playground/src/components/feed/home/RecentArea/RecentCardSkeleton.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/RecentCardSkeleton.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+import { colors } from '@sopt-makers/colors';
+
+import Skeleton from '@/components/common/Skeleton';
+
+const RecentCardSkeleton = () => {
+  return (
+    <CardContainer>
+      <CardContent>
+        <CardTitle>
+          <Skeleton width={32} height={22} borderRadius='4px' color={colors.gray700} />
+          <Skeleton width={180} height={22} borderRadius='6px' color={colors.gray700} />
+        </CardTitle>
+        <Skeleton height={42} borderRadius='6px' color={colors.gray700} />
+      </CardContent>
+
+      <CardFooter>
+        <Skeleton width={42} height={16} borderRadius='6px' color={colors.gray700} />
+        <FeedIconBox>
+          <Skeleton width={42} height={16} borderRadius='6px' color={colors.gray700} />
+          <Skeleton width={42} height={16} borderRadius='6px' color={colors.gray700} />
+        </FeedIconBox>
+      </CardFooter>
+    </CardContainer>
+  );
+};
+
+export default RecentCardSkeleton;
+
+const CardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 12px;
+  background-color: ${colors.gray900};
+  padding: 16px;
+  height: 100%;
+  overflow: hidden;
+`;
+
+const CardContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const CardTitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const CardFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const FeedIconBox = styled.div`
+  display: flex;
+  gap: 8px;
+`;

--- a/apps/playground/src/components/feed/home/RecentArea/index.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/index.tsx
@@ -48,7 +48,7 @@ const RecentArea = () => {
           <TitleBox>
             <Title>
               <UserNameStyle>{me?.name}</UserNameStyle>님,
-              <MobileLineBreak /> 새로 올라온 글을 확인해 보세요
+              <LineBreak /> 새로 올라온 글을 확인해 보세요
             </Title>
           </TitleBox>
 
@@ -90,12 +90,8 @@ const Title = styled(Text)`
   word-break: keep-all;
 `;
 
-const MobileLineBreak = styled.br`
-  display: none;
-
-  @media ${MOBILE_MEDIA_QUERY} {
-    display: inline;
-  }
+const LineBreak = styled.br`
+  display: inline;
 `;
 
 const UserNameStyle = styled.span`
@@ -129,6 +125,11 @@ const RecentFeedList = styled.div`
 
   @supports (-webkit-touch-callout: none) {
     margin-bottom: 0;
+  }
+
+  & > * {
+    flex: 0 0 272px;
+    height: auto;
   }
 `;
 

--- a/apps/playground/src/components/feed/home/RecentArea/index.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/index.tsx
@@ -54,11 +54,13 @@ const RecentArea = () => {
 
           <RecentFeedList>
             {recentPosts?.map((recentPost) => (
-              <RecentCard
-                key={recentPost.id}
-                recentPost={recentPost}
-                onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
-              />
+              <Slot key={recentPost.id}>
+                <RecentCard
+                  key={recentPost.id}
+                  recentPost={recentPost}
+                  onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
+                />
+              </Slot>
             ))}
           </RecentFeedList>
         </Container>
@@ -126,11 +128,10 @@ const RecentFeedList = styled.div`
   @supports (-webkit-touch-callout: none) {
     margin-bottom: 0;
   }
+`;
 
-  & > * {
-    flex: 0 0 272px;
-    height: auto;
-  }
+const Slot = styled.div`
+  flex: 0 0 272px;
 `;
 
 export default RecentArea;

--- a/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
+++ b/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
@@ -33,7 +33,12 @@ const RecentArea = () => {
     <TitledContent title='새로 올라온 글'>
       {/* ~1200: 캐러셀 (모바일 1장 / 태블릿 2장) */}
       <CarouselWrapper>
-        <ScrollCarousel itemCount={recentPosts.length} itemsPerView={ITEMS_PER_VIEW} autoPlay={{ enabled: false }}>
+        <ScrollCarousel
+          itemCount={recentPosts.length}
+          itemsPerView={ITEMS_PER_VIEW}
+          autoPlay={{ enabled: false }}
+          indicatorOffset={16}
+        >
           {getLoopedItems(recentPosts, ITEMS_PER_VIEW).map((recentPost, index) => (
             <RecentCard
               key={`${recentPost.id}-${index}`}

--- a/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
+++ b/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
@@ -6,15 +6,17 @@ import { useRecentPosts } from '@/api/endpoint/feed/getRecentPosts';
 import ScrollCarousel from '@/components/common/ScrollCarousel';
 import { getCategoryAndSubcategory } from '@/components/feed/common/utils/getCategoryAndSubcategory';
 import RecentCard from '@/components/feed/home/RecentArea/RecentCard';
+import RecentCardSkeleton from '@/components/feed/home/RecentArea/RecentCardSkeleton';
 import { getLoopedItems } from '@/hooks/useScrollCarousel';
 import { DESKTOP_ONE_MEDIA_QUERY, DESKTOP_TWO_MEDIA_QUERY } from '@/styles/mediaQuery';
 
 import TitledContent from '../../common/TitledContent';
 
 const ITEMS_PER_VIEW = 1;
+const SKELETON_COUNT = 3;
 
 const RecentArea = () => {
-  const { data: recentPosts = [] } = useRecentPosts();
+  const { data: recentPosts = [], isLoading } = useRecentPosts();
   const router = useRouter();
 
   const handleClickCard = (categoryTag: string, id: number) => {
@@ -31,39 +33,72 @@ const RecentArea = () => {
 
   return (
     <TitledContent title='새로 올라온 글'>
-      {/* ~1200: 캐러셀 (모바일 1장 / 태블릿 2장) */}
-      <CarouselWrapper>
-        <ScrollCarousel
-          itemCount={recentPosts.length}
-          itemsPerView={ITEMS_PER_VIEW}
-          autoPlay={{ enabled: false }}
-          indicatorOffset={16}
-        >
-          {getLoopedItems(recentPosts, ITEMS_PER_VIEW).map((recentPost, index) => (
-            <RecentCard
-              key={`${recentPost.id}-${index}`}
-              recentPost={recentPost}
-              onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
-            />
+      {isLoading ? (
+        <RecentCardSkeletonList aria-hidden>
+          {Array.from({ length: SKELETON_COUNT }, (_, index) => (
+            <RecentCardSkeleton key={`skeleton-${index}`} />
           ))}
-        </ScrollCarousel>
-      </CarouselWrapper>
+        </RecentCardSkeletonList>
+      ) : (
+        <>
+          {/* ~1200: 캐러셀 (모바일 1장 / 태블릿 2장) */}
+          <CarouselWrapper>
+            <ScrollCarousel
+              itemCount={recentPosts.length}
+              itemsPerView={ITEMS_PER_VIEW}
+              autoPlay={{ enabled: false }}
+              indicatorOffset={16}
+            >
+              {getLoopedItems(recentPosts, ITEMS_PER_VIEW).map((recentPost, index) => (
+                <RecentCard
+                  key={`${recentPost.id}-${index}`}
+                  recentPost={recentPost}
+                  onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
+                />
+              ))}
+            </ScrollCarousel>
+          </CarouselWrapper>
 
-      {/* 1200~: 캐러셀 없이 카드 3장 고정 */}
-      <StaticGrid>
-        {recentPosts.map((recentPost) => (
-          <RecentCard
-            key={`static-${recentPost.id}`}
-            recentPost={recentPost}
-            onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
-          />
-        ))}
-      </StaticGrid>
+          {/* 1200~: 캐러셀 없이 카드 3장 고정 */}
+          <StaticGrid>
+            {recentPosts.map((recentPost) => (
+              <RecentCard
+                key={`static-${recentPost.id}`}
+                recentPost={recentPost}
+                onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
+              />
+            ))}
+          </StaticGrid>
+        </>
+      )}
     </TitledContent>
   );
 };
 
 export default RecentArea;
+
+const RecentCardSkeletonList = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)); /* 1543~: 3장 */
+  gap: 12px;
+  width: 100%;
+
+  @media ${DESKTOP_ONE_MEDIA_QUERY} {
+    grid-template-columns: repeat(2, minmax(0, 1fr)); /* ~1542: 2장 */
+
+    & > *:nth-of-type(n + 3) {
+      display: none;
+    }
+  }
+
+  @media ${DESKTOP_TWO_MEDIA_QUERY} {
+    grid-template-columns: minmax(0, 1fr); /* ~1200: 1장 */
+
+    & > *:nth-of-type(n + 2) {
+      display: none;
+    }
+  }
+`;
 
 const CarouselWrapper = styled.div`
   display: none;

--- a/apps/playground/src/components/home/index.tsx
+++ b/apps/playground/src/components/home/index.tsx
@@ -12,7 +12,6 @@ import ProjectPreview from './ProjectPreview';
 
 const HomePage = () => {
   return (
-    // TODO: content 교체
     <StyledContainer>
       <WordChainEntry />
       <StyledMemberAndCommunity>
@@ -87,9 +86,10 @@ const CommunityPreview = styled(MenuPreview)`
 const StyledCommunityArea = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  justify-content: space-between;
+  height: 100%;
 
-  @mobile ${MOBILE_MEDIA_QUERY} {
+  @media ${MOBILE_MEDIA_QUERY} {
     gap: 24px;
   }
 `;

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCardSkeleton.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCardSkeleton.tsx
@@ -29,6 +29,7 @@ const StyledContainer = styled.div<{ usage: string }>`
   flex-direction: ${({ usage }) => (usage === 'home' ? 'column' : 'row')};
   gap: 16px;
   align-items: center;
+  height: ${({ usage }) => (usage === 'home' ? '182px' : 'auto')};
   padding: 16px 24px;
   background-color: ${colors.gray900};
   border-radius: 10px;
@@ -36,6 +37,7 @@ const StyledContainer = styled.div<{ usage: string }>`
   @media ${MOBILE_MEDIA_QUERY} {
     flex-direction: ${({ usage }) => (usage === 'home' ? 'row' : 'column')};
     gap: 8px;
+    height: ${({ usage }) => (usage === 'home' ? '80px' : 'auto')};
     padding: 12px 16px;
   }
 `;

--- a/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/detail/MemberRecommendSection/MemberRecommendSection.tsx
@@ -3,6 +3,7 @@ import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 
 import { useGetMemberRecommendById } from '@/api/endpoint/members/getMemberRecommendById';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -20,11 +21,18 @@ const MemberRecommendSection = ({ memberId, name }: MemberRecommendSectionProps)
   const { data, isLoading, refetch } = useGetMemberRecommendById(memberId);
   const memberRecommendData = data?.members.slice(0, 3);
 
+  const { logClickEvent } = useEventLogger();
+
+  const handleRereshIconClick = () => {
+    refetch();
+    logClickEvent('memberRecommendRefresh', { screen: 'profile' });
+  };
+
   return (
     <StyledSection>
       <StyledSectionHeader>
         <StyledSectionTitle>{name}님과 접점이 있는 멤버</StyledSectionTitle>
-        <StyledRefreshIcon onClick={refetch} />
+        <StyledRefreshIcon onClick={handleRereshIconClick} />
       </StyledSectionHeader>
       <StyledCardGrid>
         {isLoading

--- a/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
+++ b/apps/playground/src/components/members/main/MemberRecommendSection/MemberRecommendSection.tsx
@@ -5,6 +5,7 @@ import { fonts } from '@sopt-makers/fonts';
 import { useEffect, useState } from 'react';
 
 import { useGetMemberRecommendOfMe } from '@/api/endpoint/members/getMemberRecommendOfMe';
+import useEventLogger from '@/components/eventLogger/hooks/useEventLogger';
 import RefreshIcon from '@/public/icons/icon_refresh.svg';
 import { DESKTOP_TWO_MEDIA_QUERY, MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
@@ -16,6 +17,7 @@ const PC_MEDIA_QUERY = `screen and (min-width: ${PC_MEDIA_WIDTH}px)`;
 const SKELETON_COUNT = 4;
 
 const MemberRecommendSection = () => {
+  const { logClickEvent } = useEventLogger();
   const { data, isLoading, refetch } = useGetMemberRecommendOfMe();
   const memberRecommendData = data?.members;
   const [isTooltipOpen, setIsTooltipOpen] = useState(true);
@@ -34,6 +36,7 @@ const MemberRecommendSection = () => {
   const handleRefreshClick = () => {
     setIsTooltipOpen(false);
     refetch();
+    logClickEvent('memberRecommendRefresh', { screen: 'profile' });
   };
 
   return (

--- a/apps/playground/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
+++ b/apps/playground/src/components/wordchain/WordchainEntry/WordchainSkeleton.tsx
@@ -23,9 +23,11 @@ const SkeletonWrapper = styled(Skeleton)`
   display: flex;
   align-items: center;
   padding: 16px;
+  max-width: 480px;
+  margin: 0 auto;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    margin-bottom: 16px;
+    margin: 0 auto 16px;
     padding: 20px 16px;
     height: 80px;
   }


### PR DESCRIPTION
## 📋 작업 내용

- [x] 홈 페이지 요소 전체적인 스타일 수정
- [x] 커뮤니티 > '새로운 글' 미리보기 영역 스켈레톤 ui 구현
- [x] SP1 때 누락되었던 `click-memberRecommendRefresh` 이벤트 로깅 추가
- [x] `ScrollCarousel` 컴포넌트에 `indicatorOffset` prop 추가

## 📌 PR Point

- `RecentCard`에 스타일이 적용되지 않은 부분이 있어서 반영했어요.
- 홈 페이지에서 w769~에서 **멤버 미리보기 영역**과 **커뮤니티 미리보기 영역**의 높이가 맞지 않던 문제를 해결했어요.
- 커뮤니티 > '새로운 글' 미리보기 영역의 경우 기존에 `ScrollCarousel`이 쓰이던 곳들과 다르게 아이템 영역과 indicator 간의 간격이 달라서 props로 받아 사용처에서 지정할 수 있도록 변경했어요.

## 📸 스크린샷
<img width="1074" height="381" alt="image" src="https://github.com/user-attachments/assets/194bf2b0-dcce-4f62-999f-3be8c3f4f0d5" />

<br />

**[click-memberRecommendRefresh]**

<img width="315" height="68" alt="image" src="https://github.com/user-attachments/assets/ada3fd0f-2c30-400a-93af-e5d744c5a58b" />

- 멤버 탭에서 클릭 시

<br />

<img width="312" height="67" alt="image" src="https://github.com/user-attachments/assets/85f96267-08b0-4546-88af-32de8e70f317" />

- 멤버 상세 페이지에서 클릭 시
