### PR TITLE
fix: desktop에서 4명만 노출되도록 수정

### DIFF
--- a/apps/playground/src/components/home/MembersPreview/index.tsx
+++ b/apps/playground/src/components/home/MembersPreview/index.tsx
@@ -12,7 +12,7 @@ const MOBILE_SKELETON_COUNT = 2;
 
 const MemberPreview = () => {
   const { data: memberRecommendData, isLoading } = useGetMemberRecommendOfMe();
-  const desktopMemberData = memberRecommendData?.members;
+  const desktopMemberData = memberRecommendData?.members.slice(0, 4);
   const mobileMemberData = memberRecommendData?.members.slice(0, 2);
 
   return (


### PR DESCRIPTION
## 📋 작업 내용

- [x] desktop(w769~)일 때 멤버 미리보기 영역에서 4명만 노출되도록 수정

## 📌 PR Point

- 서버에서 5명 내려주고 있어서 4명만 노출되도록 `slice()`로 수정하였어요.

## 📸 스크린샷
<img width="290" height="422" alt="image" src="https://github.com/user-attachments/assets/2bd8dbc0-5e5b-4244-9669-de564949d24b" />

