### PR TITLE
style: 홈 페이지 요소 스타일 관련 SP2 QA 대응

### DIFF
--- a/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/RecentCard.tsx
@@ -76,7 +76,7 @@ const CardContainer = styled.div`
   background-color: ${colors.gray900};
   cursor: pointer;
   padding: 16px;
-  height: 100%;
+  height: 126px;
 
   &:hover {
     background-color: ${colors.gray800};

--- a/apps/playground/src/components/feed/home/RecentArea/index.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/index.tsx
@@ -56,7 +56,6 @@ const RecentArea = () => {
             {recentPosts?.map((recentPost) => (
               <Slot key={recentPost.id}>
                 <RecentCard
-                  key={recentPost.id}
                   recentPost={recentPost}
                   onClick={() => handleClickCard(recentPost.categoryTag, recentPost.id)}
                 />
@@ -132,6 +131,7 @@ const RecentFeedList = styled.div`
 
 const Slot = styled.div`
   flex: 0 0 272px;
+  min-width: 0;
 `;
 
 export default RecentArea;

--- a/apps/playground/src/components/feed/list/MenuEntryIcons/MenuEntryIcons.tsx
+++ b/apps/playground/src/components/feed/list/MenuEntryIcons/MenuEntryIcons.tsx
@@ -106,6 +106,6 @@ const MenuIconBox = styled.div`
 const MenuLabel = styled.div`
   @media ${MOBILE_MEDIA_QUERY} {
     white-space: nowrap;
-    ${fonts.TITLE_14_SB}
+    ${fonts.BODY_14_M}
   }
 `;

--- a/apps/playground/src/components/home/ProjectPreview/ProjectCard.tsx
+++ b/apps/playground/src/components/home/ProjectPreview/ProjectCard.tsx
@@ -72,7 +72,7 @@ const StyledContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 302px;
-  border-radius: 12px;
+  border-radius: 24px;
   background-color: ${colors.gray900};
   cursor: pointer;
 `;
@@ -80,7 +80,7 @@ const StyledContainer = styled.div`
 const StyledImage = styled(ResizedImage)<{ isLogo?: boolean }>`
   width: ${(props) => (props.isLogo ? '56px' : '100%')};
   height: ${(props) => (props.isLogo ? '56px' : '180px')};
-  border-radius: ${(props) => (props.isLogo ? '6px' : '8px 8px 0 0')};
+  border-radius: ${(props) => (props.isLogo ? '6px' : '24px 24px 0 0')};
   object-fit: cover;
 `;
 

--- a/apps/playground/src/components/home/ProjectPreview/index.tsx
+++ b/apps/playground/src/components/home/ProjectPreview/index.tsx
@@ -19,7 +19,7 @@ const ProjectPreview = () => {
   const itemsPerView = isMobile ? 1 : 2;
 
   return (
-    <TitledContent title={`지난 기수 앱잼 프로젝트`}>
+    <TitledContent title={`지금 둘러볼 만한 프로젝트`}>
       {isLoading ? (
         <ProjectSkeletonList aria-hidden>
           {Array.from({ length: SKELETON_CARD_COUNT }, (_, index) => (

--- a/apps/playground/src/components/home/common/MenuPreview.tsx
+++ b/apps/playground/src/components/home/common/MenuPreview.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
 
+import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
+
 import MenuLink from './MenuLink';
 
 export type MenuKey = 'member' | 'community' | 'project' | 'coffeechat';
@@ -25,5 +27,9 @@ export default MenuPreview;
 const StyledContainer = styled.section`
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+
+  @media ${MOBILE_MEDIA_QUERY} {
+    gap: 4px;
+  }
 `;

--- a/apps/playground/src/components/home/index.tsx
+++ b/apps/playground/src/components/home/index.tsx
@@ -91,5 +91,6 @@ const StyledCommunityArea = styled.div`
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 24px;
+    justify-content: normal;
   }
 `;

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -60,7 +60,7 @@ const StyledContainer = styled.div<{ usage: string }>`
   flex-direction: ${({ usage }) => (usage === 'home' ? 'column' : 'row')};
   gap: 16px;
   align-items: center;
-  padding: 16px 24px;
+  padding: ${({ usage }) => (usage === 'home' ? '25px 32px' : '16px 24px')};
   background-color: ${colors.gray900};
   border-radius: 10px;
   cursor: pointer;
@@ -118,7 +118,7 @@ const StyledInfoWrapper = styled.div<{ usage: string }>`
   display: flex;
   flex-direction: column;
   align-items: ${({ usage }) => (usage == 'home' ? 'center' : 'start')};
-  gap: 6px;
+  gap: ${({ usage }) => (usage == 'home' ? '2px' : '6px')};
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 2px;

--- a/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
+++ b/apps/playground/src/components/members/common/MemberRecommendCard/MemberRecommendCard.tsx
@@ -84,8 +84,8 @@ const StyledAvatar = styled.img<{ usage: string }>`
   object-fit: cover;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    width: ${({ usage }) => (usage == 'home' ? '56px' : '72px')};
-    height: ${({ usage }) => (usage == 'home' ? '56px' : '72px')};
+    width: ${({ usage }) => (usage === 'home' ? '56px' : '72px')};
+    height: ${({ usage }) => (usage === 'home' ? '56px' : '72px')};
   }
 `;
 
@@ -99,8 +99,8 @@ const StyledDefaultAvatar = styled(IconUser)<{ usage: string }>`
   padding-top: 10px;
 
   @media ${MOBILE_MEDIA_QUERY} {
-    width: ${({ usage }) => (usage == 'home' ? '56px' : '72px')};
-    height: ${({ usage }) => (usage == 'home' ? '56px' : '72px')};
+    width: ${({ usage }) => (usage === 'home' ? '56px' : '72px')};
+    height: ${({ usage }) => (usage === 'home' ? '56px' : '72px')};
     padding-top: 9px;
   }
 `;
@@ -117,12 +117,12 @@ const StyledInfoWrapper = styled.div<{ usage: string }>`
   min-width: 0;
   display: flex;
   flex-direction: column;
-  align-items: ${({ usage }) => (usage == 'home' ? 'center' : 'start')};
-  gap: ${({ usage }) => (usage == 'home' ? '2px' : '6px')};
+  align-items: ${({ usage }) => (usage === 'home' ? 'center' : 'start')};
+  gap: ${({ usage }) => (usage === 'home' ? '2px' : '6px')};
 
   @media ${MOBILE_MEDIA_QUERY} {
     gap: 2px;
-    align-items: ${({ usage }) => (usage == 'home' ? 'start' : 'center')};
+    align-items: ${({ usage }) => (usage === 'home' ? 'start' : 'center')};
   }
 `;
 


### PR DESCRIPTION
## 📋 작업 내용

- [x] 프로젝트 미리보기 영역 타이틀을 `지금 둘러볼 만한 프로젝트`로 변경
- [x] 프로젝트 카드 및 이미지 상단 border-radius를 24px로 변경
- [x] 멤버/커뮤니티 미리보기 영역이 차지하는 높이를 동일하게 맞추도록 RecentCard 높이 고정(126px) 및 MemberRecommendCard(home) 패딩·간격 조정
- [x] 메뉴 라벨 폰트를 `BODY_14_M`로 변경(모바일)
- [x] MenuPreview gap을 desktop 8px / mobile 4px로 분기
- [x] RecentArea Slot에 `min-width: 0` 추가해 Slot width 늘어남 방지 및 중복 key 제거
- [x] 모바일 커뮤니티 영역 `justify-content: normal` 처리

## 📌 PR Point

- 홈 페이지 요소들의 SP2 QA 피드백을 일괄 반영한 스타일 위주 변경입니다.
- 멤버 미리보기와 커뮤니티 미리보기 영역의 높이를 시각적으로 동일하게 맞추기 위해 RecentCard 높이를 고정(126px)하고, MemberRecommendCard는 `usage === 'home'`일 때만 패딩/간격을 별도 분기했습니다.
- 영향 범위는 `apps/playground`의 home / feed / members 컴포넌트입니다. 로직 변경은 없고 스타일과 카피 위주입니다.
- 리뷰어는 데스크탑/모바일 두 화면에서 각 미리보기 영역의 높이·간격이 의도대로 정렬되는지 확인해주세요.

## 📸 스크린샷

| As-is | To-be |
|-------|-------|
|       |       |

---
🤖 made by [claude](https://claude.ai)
