### PR TITLE
fix: 커뮤니티 모임 글 클릭시 리다이렉트 문제 해결 및 전체 태그 추가

### DIFF
--- a/apps/playground/src/components/feed/home/ReactionArea/index.tsx
+++ b/apps/playground/src/components/feed/home/ReactionArea/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { playgroundLink } from '@sopt/constant';
+import { crewLink, playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { useRouter } from 'next/router';
 
@@ -8,12 +8,17 @@ import { useGetPopularPost } from '@/api/endpoint/feed/getPopularPost';
 import PopularCard from '@/components/common/PopularCard';
 import Text from '@/components/common/Text';
 import { getCategoryAndSubcategory } from '@/components/feed/common/utils/getCategoryAndSubcategory';
+import { MEETING_CATEGORY_CODE } from '@/components/feed/constants';
 
 const ReactionArea = () => {
   const { data, isError, isLoading } = useGetPopularPost();
   const router = useRouter();
 
   const handleClickCard = (card: PopularPostType[number]) => {
+    if (card.categoryTag === MEETING_CATEGORY_CODE) {
+      router.push(crewLink.feedDetail(card.id));
+      return;
+    }
     const [category, subcategory] = getCategoryAndSubcategory(card.categoryTag);
     router.push({
       pathname: playgroundLink.feedList(),

--- a/apps/playground/src/components/feed/home/RecentArea/index.tsx
+++ b/apps/playground/src/components/feed/home/RecentArea/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { playgroundLink } from '@sopt/constant';
+import { crewLink, playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { fonts } from '@sopt-makers/fonts';
 import { useRouter } from 'next/router';
@@ -8,6 +8,7 @@ import { useRecentPosts } from '@/api/endpoint/feed/getRecentPosts';
 import { useGetMemberOfMe } from '@/api/endpoint/members/getMemberOfMe';
 import Text from '@/components/common/Text';
 import { getCategoryAndSubcategory } from '@/components/feed/common/utils/getCategoryAndSubcategory';
+import { MEETING_CATEGORY_CODE } from '@/components/feed/constants';
 import RecentCard from '@/components/feed/home/RecentArea/RecentCard';
 import FeedSkeleton from '@/components/feed/list/FeedSkeleton';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
@@ -18,6 +19,10 @@ const RecentArea = () => {
   const router = useRouter();
 
   const handleClickCard = (categoryTag: string, id: number) => {
+    if (categoryTag === MEETING_CATEGORY_CODE) {
+      router.push(crewLink.feedDetail(id));
+      return;
+    }
     const [category, subcategory] = getCategoryAndSubcategory(categoryTag);
     router.push({
       pathname: playgroundLink.feedList(),

--- a/apps/playground/src/components/feed/list/FeedList.tsx
+++ b/apps/playground/src/components/feed/list/FeedList.tsx
@@ -25,6 +25,8 @@ interface FeedListProps {
   onScrollChange?: (scrolling: boolean) => void;
 }
 
+const ALL_TAG = { code: 'ALL', name: '전체' };
+
 const FeedList = ({ renderFeedDetailLink, onScrollChange }: FeedListProps) => {
   const queryClient = useQueryClient();
   const [categoryCode] = useCategoryParam({ defaultValue: '' });
@@ -37,10 +39,10 @@ const FeedList = ({ renderFeedDetailLink, onScrollChange }: FeedListProps) => {
       code: category.code,
       name: category.name,
       hasAllCategory: true,
-      tags: category.children.map((item) => ({
-        code: item.code,
-        name: item.name,
-      })),
+      tags:
+        category.children.length > 0
+          ? [ALL_TAG, ...category.children.map((item) => ({ code: item.code, name: item.name }))]
+          : [],
     }));
 
   const parentCategory = categories?.find((c) => c.code === categoryCode);

--- a/apps/playground/src/components/feed/list/FeedList.tsx
+++ b/apps/playground/src/components/feed/list/FeedList.tsx
@@ -18,14 +18,14 @@ import FeedListItems from '@/components/feed/list/FeedListItems';
 import { layoutCSSVariable } from '@/components/layout/utils';
 import { MOBILE_MEDIA_QUERY } from '@/styles/mediaQuery';
 
-import { MEETING_CATEGORY_CODE } from '../constants';
+import { ALL_CATEGORY_CODE, MEETING_CATEGORY_CODE } from '../constants';
 
 interface FeedListProps {
   renderFeedDetailLink: (props: { children: ReactNode; feedId: string; category: string }) => ReactNode;
   onScrollChange?: (scrolling: boolean) => void;
 }
 
-const ALL_TAG = { code: 'ALL', name: '전체' };
+const ALL_TAG = { code: ALL_CATEGORY_CODE, name: '전체' };
 
 const FeedList = ({ renderFeedDetailLink, onScrollChange }: FeedListProps) => {
   const queryClient = useQueryClient();

--- a/apps/playground/src/components/home/CommunityPreview/PopularArea/index.tsx
+++ b/apps/playground/src/components/home/CommunityPreview/PopularArea/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { playgroundLink } from '@sopt/constant';
+import { crewLink, playgroundLink } from '@sopt/constant';
 import { colors } from '@sopt-makers/colors';
 import { useRouter } from 'next/router';
 
@@ -9,6 +9,7 @@ import PopularCard from '@/components/common/PopularCard';
 import Text from '@/components/common/Text';
 import { LoggingClick } from '@/components/eventLogger/components/LoggingClick';
 import { getCategoryAndSubcategory } from '@/components/feed/common/utils/getCategoryAndSubcategory';
+import { MEETING_CATEGORY_CODE } from '@/components/feed/constants';
 
 import TitledContent from '../../common/TitledContent';
 
@@ -18,6 +19,10 @@ const PopularArea = () => {
   const router = useRouter();
 
   const handleClickCard = (card: PopularPostType[number]) => {
+    if (card.categoryTag === MEETING_CATEGORY_CODE) {
+      router.push(crewLink.feedDetail(card.id));
+      return;
+    }
     const [category, subcategory] = getCategoryAndSubcategory(card.categoryTag);
     router.push({
       pathname: playgroundLink.feedList(),

--- a/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
+++ b/apps/playground/src/components/home/CommunityPreview/RecentArea/index.tsx
@@ -1,10 +1,11 @@
 import styled from '@emotion/styled';
-import { playgroundLink } from '@sopt/constant';
+import { crewLink, playgroundLink } from '@sopt/constant';
 import { useRouter } from 'next/router';
 
 import { useRecentPosts } from '@/api/endpoint/feed/getRecentPosts';
 import ScrollCarousel from '@/components/common/ScrollCarousel';
 import { getCategoryAndSubcategory } from '@/components/feed/common/utils/getCategoryAndSubcategory';
+import { MEETING_CATEGORY_CODE } from '@/components/feed/constants';
 import RecentCard from '@/components/feed/home/RecentArea/RecentCard';
 import RecentCardSkeleton from '@/components/feed/home/RecentArea/RecentCardSkeleton';
 import { getLoopedItems } from '@/hooks/useScrollCarousel';
@@ -20,6 +21,10 @@ const RecentArea = () => {
   const router = useRouter();
 
   const handleClickCard = (categoryTag: string, id: number) => {
+    if (categoryTag === MEETING_CATEGORY_CODE) {
+      router.push(crewLink.feedDetail(id));
+      return;
+    }
     const [category, subcategory] = getCategoryAndSubcategory(categoryTag);
     router.push({
       pathname: playgroundLink.feedList(),


### PR DESCRIPTION
## 📋 작업 내용

- [x] 커뮤니티 모임 글 클릭시 크루 페이지로 이동하는 로직 추가 (추후에 공통으로 묶는 로직 추가 예정)
- [x] 서버에서 내려오던 ALL이 내려오지 않아 클라이언트에서 임시 추가 (추후 서버와 이야기해볼 예정)

## 📌 PR Point

- 커뮤니티에 있는 모임글은 크루에서 관리하고 있어서 모임 상세 페이지는 크루가 담당합니다. 따라서 크루 주소로 이동시킵니다
- 서버에서 자식 카테고리가 존재할 때 원래 ALL도 함께 내려오고 있었는데 업로드 페이지에서도 카테고리 get api를 사용하면서 ALL을 뺸 것 같습니다. 이 부분은 서버쌤들과 이야기해본 후 구조를 수정해나갈 예정입니다 !
