### PR TITLE
fix: 홈 화면 레이아웃 및 간격을 피그마 시안에 맞게 수정

### DIFF
--- a/apps/crew/pages/index.tsx
+++ b/apps/crew/pages/index.tsx
@@ -17,12 +17,10 @@ const Home: NextPage = () => {
 
   return (
     <>
-      <CrewTab>
+      <SCrewTab>
         <GuideButton />
-      </CrewTab>
-      <SEventPeriodBannerWrapper>
-        <EventPeriodBanner />
-      </SEventPeriodBannerWrapper>
+      </SCrewTab>
+      <EventPeriodBanner />
       {isTablet ? (
         <>
           <SContentTitle>⚡ 솝트만의 일회성 모임, 번쩍</SContentTitle>
@@ -63,18 +61,18 @@ const Home: NextPage = () => {
 
 export default Home;
 
-const SEventPeriodBannerWrapper = styled('div', {
+const SCrewTab = styled(CrewTab, {
   '@new_mobile': {
-    mt: '$30',
+    pb: '$28',
   },
   '@new_tablet': {
-    mt: '$45',
+    pb: '$45',
   },
   '@new_desktop': {
-    mt: '$45',
+    pb: '$45',
   },
   '@new_laptop': {
-    mt: '$65',
+    pb: '$45',
   },
 });
 
@@ -88,18 +86,8 @@ const SContentTitle = styled('div', {
   'width': '100%',
 
   '@new_mobile': {
-    mt: '$40',
     display: 'flex',
     fontSize: '16px',
-  },
-  '@new_tablet': {
-    mt: '$40',
-  },
-  '@new_desktop': {
-    mt: '$60',
-  },
-  '@new_laptop': {
-    mt: '$72',
   },
 });
 

--- a/apps/crew/src/domain/eventPeriodBanner/index.tsx
+++ b/apps/crew/src/domain/eventPeriodBanner/index.tsx
@@ -107,15 +107,19 @@ const Container = styled('section', {
   'borderRadius': '$8',
   '@new_mobile': {
     py: '$36',
+    mb: '$40',
   },
   '@new_tablet': {
     py: '$36',
+    mb: '$40',
   },
   '@new_desktop': {
     py: '$36',
+    mb: '$60',
   },
   '@new_laptop': {
     py: '$42',
+    mb: '$72',
   },
 });
 

--- a/apps/crew/src/shared/CrewTab/index.tsx
+++ b/apps/crew/src/shared/CrewTab/index.tsx
@@ -7,7 +7,12 @@ import type { ReactNode } from 'react';
 
 import { ampli } from '@/ampli';
 
-const CrewTab = ({ children }: { children?: ReactNode }) => {
+interface CrewTabProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+const CrewTab = ({ children, className }: CrewTabProps) => {
   const path = useRouter().pathname;
   const tabText = {
     group: 'feedAll',
@@ -20,7 +25,7 @@ const CrewTab = ({ children }: { children?: ReactNode }) => {
   const lastSegment = (path.split('/').at(-1) || 'group') as keyof typeof tabText;
 
   return (
-    <Flex align='center' justify='between'>
+    <Flex align='center' justify='between' className={className}>
       <TabList text={tabText[lastSegment]} size='big'>
         <Link href='/' onClick={() => ampli.clickNavbarGroup({ menu: '피드' })}>
           <TabList.Item text='feedAll'>홈</TabList.Item>

--- a/apps/crew/src/shared/GuideButton/index.tsx
+++ b/apps/crew/src/shared/GuideButton/index.tsx
@@ -28,7 +28,7 @@ const SGuideButton = styled('a', {
   'flexType': 'verticalCenter',
   'gap': '$8',
   'color': '$gray10',
-  'padding': '$8 $6',
+  'px': '$6',
   'fontAg': '18_semibold_100',
 
   '@tablet': {


### PR DESCRIPTION
## 📋 작업 내용

- [x] 페이지 구조화 및 스타일링

## 📌 PR Point
기존에 홈 화면이 피그마와 디자인이 맞지 않는 부분이 있어서 수정했어요.
1. `Tab`과 `번쩍 캐러셀` 부분까지의 간격이 멀어서 피그마에 맞게 수정했어요.
2. 모임 홈 화면만 `Tab`이 아래로 치우치는 이슈가 보였어요. 다른 페이지를 보니 홈 화면에만 `모임 신청 가이드 버튼`이 있었고 이 때문에 Wrapper가 아래로 밀려서 발생한 이슈인걸 확인해서 같이 수정했어요.

## 📸 스크린샷
### [ AS - IS ]

https://github.com/user-attachments/assets/1b4ddb4e-1586-4040-a0c1-8cb25c6875a6


### [ TO - BE ]

https://github.com/user-attachments/assets/8c0dee99-0f4f-400a-add6-60df575c9bf0

