### PR TITLE
ci: crew 빌드 및 배포 워크플로우 캐시 설정 개선

### DIFF
--- a/.github/workflows/crew-build.yml
+++ b/.github/workflows/crew-build.yml
@@ -34,13 +34,21 @@ jobs:
         uses: actions/cache@v4
         id: yarn-cache
         with:
-          path: ~/.yarn/cache
+          path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
       - name: Install Packages
         run: yarn install --immutable
+
+      - name: Cache Crew Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/apps/crew/.next/cache
+          key: ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-${{ hashFiles('apps/crew/**/*.[jt]s', 'apps/crew/**/*.[jt]sx', 'apps/crew/next.config.js', 'apps/crew/package.json', 'packages/**/*.[jt]s', 'packages/**/*.[jt]sx', 'packages/**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-
 
       - name: Build
         run: yarn build:crew

--- a/.github/workflows/crew-deploy-development.yml
+++ b/.github/workflows/crew-deploy-development.yml
@@ -37,13 +37,21 @@ jobs:
         uses: actions/cache@v4
         id: yarn-cache
         with:
-          path: ~/.yarn/cache
+          path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
       - name: Install Packages
         run: yarn install --immutable
+
+      - name: Cache Crew Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/apps/crew/.next/cache
+          key: ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-${{ hashFiles('apps/crew/**/*.[jt]s', 'apps/crew/**/*.[jt]sx', 'apps/crew/next.config.js', 'apps/crew/package.json', 'packages/**/*.[jt]s', 'packages/**/*.[jt]sx', 'packages/**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-
 
       - name: Set .env
         run: |

--- a/.github/workflows/crew-deploy-production.yml
+++ b/.github/workflows/crew-deploy-production.yml
@@ -36,13 +36,21 @@ jobs:
         uses: actions/cache@v4
         id: yarn-cache
         with:
-          path: ~/.yarn/cache
+          path: .yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 
       - name: Install Packages
         run: yarn install --immutable
+
+      - name: Cache Crew Next.js build
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/apps/crew/.next/cache
+          key: ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-${{ hashFiles('apps/crew/**/*.[jt]s', 'apps/crew/**/*.[jt]sx', 'apps/crew/next.config.js', 'apps/crew/package.json', 'packages/**/*.[jt]s', 'packages/**/*.[jt]sx', 'packages/**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-crew-nextjs-${{ hashFiles('yarn.lock') }}-
 
       - name: Set .env
         run: |

--- a/apps/crew/next.config.js
+++ b/apps/crew/next.config.js
@@ -5,6 +5,9 @@ const nextConfig = {
   output: 'export',
   reactStrictMode: true,
   swcMinify: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   transpilePackages: ['@sopt/ui', '@sopt/constant'],
   webpack: (config) => {
     config.module.rules.push({


### PR DESCRIPTION
## 📋 작업 내용
- [x] Crew deploy workflow의 Yarn cache 경로를 실제 Yarn 설정에 맞게 수정했어요.
- [x] Crew deploy workflow에 Next.js build cache를 추가했어요.
- [x] Crew PR build workflow에도 Yarn cache와 Next.js build cache를 적용했어요.
- [x] Crew `next build` 단계에서 중복으로 실행되던 ESLint 검사를 건너뛰도록 설정했어요.

## 📌 PR Point
기존에 `Crew`의 `Build`, `Deploy`가 너무 오래 걸리는 이슈가 있었어요.
`Crew` 배포 시간이 길게 소요되는 원인이 `Playground`와 의존이 있어서 느린줄 알았으나 확인해보니 `Playground`가 함께 빌드되거나 배포되는 문제는 아니었어요.
`yarn build:crew`는 이미 `turbo run build --filter=crew`로 실행되고 있었고 실제 로그에서도 `Packages in scope: crew`로 되어있었습니다.

기존 Crew Development Deploy 기준으로 `Install Packages`가 약 2분 57초, `Build`가 약 4분 13초 소요되고 있었어요.
<img width="635" height="199" alt="image" src="https://github.com/user-attachments/assets/a6b13aae-a12e-493c-910f-5064a7c02cad" />

설치 단계에서는 `Fetch step`만 약 2분 39초가 걸렸는데 현재 `.yarnrc.yml`의 `enableGlobalCache: false` 설정상 Yarn cache는 `.yarn/cache`를 사용해요. 기존 workflow는 `~/.yarn/cache`를 캐시하고 있어서 실제 캐시 경로와 맞지 않았고 이 때문에 패키지 fetch cache가 제대로 활용되지 않았을 가능성이 있다고 판단했고 그래서 Crew deploy workflow의 Yarn cache 경로를 `.yarn/cache`로 수정했어요.

Build 단계에서는 Next.js build cache가 없어서 매번 fresh build에 가깝게 동작하고 있었어요. 실제 로그에서도 `No build cache found`, `Cached: 0 cached, 2 total`이 확인됐구요.
반복 배포시 Next.js가 이전 build 중간 결과를 활용할 수 있도록 `apps/crew/.next/cache`를 캐시하도록 추가했어요.

PR에서 실행되는 `Crew - Build App` workflow도 동일한 문제를 가지고 있었어요. PR build에서도 Yarn cache 경로가 `~/.yarn/cache`로 설정되어 있어서 cache 저장 시 `Path Validation Error`가 발생했고 build 단계에서도 `No build cache found`, `Cached: 0 cached, 2 total`이 확인됐어요.

따라서 deploy workflow뿐만 아니라 PR build workflow인 `crew-build.yml`에도 동일하게 Yarn cache 경로를 `.yarn/cache`로 수정하고 `apps/crew/.next/cache` 캐시를 추가했어요.

`next build`는 빌드 과정에서 lint 체크와 type check를 함께 수행해요. 그런데 PR 단계의 `Check` workflow에서 이미 `yarn typecheck`, `yarn lint`, `yarn test:ci`를 실행하고 있고 `develop` 브랜치에는 PR과 `check` 통과가 필수인 ruleset이 설정되어 있어요. 따라서 Crew deploy 과정에서 `next build`가 다시 lint와 type check를 수행하는 것은 중복으로 검증하는겨라고 판단했어요.

다만 Type check까지 build에서 제외하면 타입 에러가 있는 코드도 배포될 수 있다고 생각해서 `eslint.ignoreDuringBuilds`만 추가해서 build 중 ESLint 중복 실행만 제거했어요.

이번 변경의 실제 속도 개선 효과는 GitHub Actions에서 cache가 저장된 이후 두 번째 실행부터 더 정확히 확인할 수 있어요! 첫 실행에서는 cache miss가 발생할 수 있어서 개선 폭이 제한적일 수 있고 이후 run에서 Cache Yarn, Cache Crew Next.js build, Install Packages, Build 시간을 비교해볼 예정입니다!

## 📸 스크린샷
### 로컬에서 Build했을 때 
<img width="239" height="108" alt="image" src="https://github.com/user-attachments/assets/ac94bfe9-edfa-4e66-a740-ab0e66581df0" />

## 추후 Github Action으로 실행했을 때 이미지 추가 예정